### PR TITLE
Readme: Remove outdated link to proxy pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ There is also a working [example in the Go playground](https://play.golang.org/p
 
 *  Package [metrics](http://godoc.org/github.com/creachadair/jrpc2/metrics) defines a server metrics collector.
 
-*  Package [proxy](http://godoc.org/github.com/creachadair/jrpc2/proxy) defines a transparent proxy that allows a connected client to be re-exported as a server.
-
 *  Package [server](http://godoc.org/github.com/creachadair/jrpc2/server) provides support for running a server to handle multiple connections, and an in-memory implementation for testing.
 
 [spec]: http://www.jsonrpc.org/specification


### PR DESCRIPTION
This package was apparently removed in https://github.com/creachadair/jrpc2/commit/8c9d845424b1440f8f0ce7bc204c5bdabbe4756a