### PR TITLE
channel: Add OptionalHeader(mimeType)

### DIFF
--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -80,7 +80,7 @@ var tests = []struct {
 	framing Framing
 }{
 	{"Header", Header("binary/octet-stream")},
-	{"LSP", LSP},
+	{"StrictLSP", Header(lspMimeType)},
 	{"Line", Line},
 	{"NoMIME", Header("")},
 	{"RS", Split('\x1e')},
@@ -200,6 +200,12 @@ func TestHeaderFraming(t *testing.T) {
 		{
 			name:         "incoming message without Content-Type is tolerated",
 			framing:      OptionalHeader("application/json"),
+			readerBuf:    "Content-Length: 18\r\n\r\n{\"hello\": \"world\"}",
+			expectedRecv: []byte(`{"hello": "world"}`),
+		},
+		{
+			name:         "incoming LSP message without Content-Type is tolerated",
+			framing:      LSP,
 			readerBuf:    "Content-Length: 18\r\n\r\n{\"hello\": \"world\"}",
 			expectedRecv: []byte(`{"hello": "world"}`),
 		},

--- a/channel/hdr.go
+++ b/channel/hdr.go
@@ -144,8 +144,10 @@ func (h *hdr) Recv() ([]byte, error) {
 // Close implements part of the Channel interface.
 func (h *hdr) Close() error { return h.wc.Close() }
 
+const lspMimeType = "application/vscode-jsonrpc; charset=utf-8"
+
 // LSP is a header framing (see Header) that transmits and receives messages on
 // r and wc using the MIME type application/vscode-jsonrpc. This is the format
 // preferred by the Language Server Protocol (LSP), defined by
 // https://microsoft.github.io/language-server-protocol
-var LSP = Header("application/vscode-jsonrpc; charset=utf-8")
+var LSP = OptionalHeader(lspMimeType)

--- a/channel/hdr.go
+++ b/channel/hdr.go
@@ -47,6 +47,21 @@ func Header(mimeType string) Framing {
 	}
 }
 
+func OptionalHeader(mimeType string) Framing {
+	return func(r io.Reader, wc io.WriteCloser) Channel {
+		var ctype string
+		if mimeType != "" {
+			ctype = "Content-Type: " + mimeType + "\r\n"
+		}
+		return &hdr{
+			ctype: ctype,
+			wc:    wc,
+			rd:    bufio.NewReader(r),
+			buf:   bytes.NewBuffer(nil),
+		}
+	}
+}
+
 // An hdr implements Channel. Messages sent on a hdr channel are framed as a
 // header/body transaction, similar to HTTP.
 type hdr struct {


### PR DESCRIPTION
The existing `Header` framing does a few things, amongst others:
 1. attaches given `Content-Type` to outgoing requests
 2. checks that incoming requests have given `Content-Type`

In [LSP specification](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#headerPart), the `Content-Type` header is actually optional and in reality many LSP clients choose to omit it, which makes both the `LSP` and `Header` Framing unfit for this reality.

Arguably we could change these clients to start sending the header, but they are technically complying with the spec.

`OptionalHeader` fits this reality while offering the same functionality as `Header`.