### PR TITLE
server: Introduce IgnoreUnknownFields option

### DIFF
--- a/base.go
+++ b/base.go
@@ -52,6 +52,8 @@ type Request struct {
 	id     json.RawMessage // the request ID, nil for notifications
 	method string          // the name of the method being requested
 	params json.RawMessage // method parameters
+
+	ignoreUnknownFields bool
 }
 
 // IsNotification reports whether the request is a notification, and thus does
@@ -75,7 +77,9 @@ func (r *Request) UnmarshalParams(v interface{}) error {
 		return nil
 	}
 	dec := json.NewDecoder(bytes.NewReader(r.params))
-	dec.DisallowUnknownFields()
+	if !r.ignoreUnknownFields {
+		dec.DisallowUnknownFields()
+	}
 	if err := dec.Decode(v); err != nil {
 		return Errorf(code.InvalidParams, "invalid parameters: %v", err.Error())
 	}

--- a/opts.go
+++ b/opts.go
@@ -26,6 +26,12 @@ type ServerOptions struct {
 	// method of the server will report an error when called.
 	AllowPush bool
 
+	// Instructs JSON decoder to ignore unknown fields when unmarshaling request.
+	//
+	// As JSON-RPC specification states:
+	// "The absence of expected names MAY result in an error being generated."
+	IgnoreUnknownFields bool
+
 	// Instructs the server to disable the built-in rpc.* handler methods.
 	//
 	// By default, a server reserves all rpc.* methods, even if the given
@@ -67,9 +73,10 @@ func (s *ServerOptions) logger() logger {
 	return func(msg string, args ...interface{}) { logger.Output(2, fmt.Sprintf(msg, args...)) }
 }
 
-func (s *ServerOptions) allowV1() bool      { return s != nil && s.AllowV1 }
-func (s *ServerOptions) allowPush() bool    { return s != nil && s.AllowPush }
-func (s *ServerOptions) allowBuiltin() bool { return s == nil || !s.DisableBuiltin }
+func (s *ServerOptions) allowV1() bool             { return s != nil && s.AllowV1 }
+func (s *ServerOptions) allowPush() bool           { return s != nil && s.AllowPush }
+func (s *ServerOptions) ignoreUnknownFields() bool { return s != nil && s.IgnoreUnknownFields }
+func (s *ServerOptions) allowBuiltin() bool        { return s == nil || !s.DisableBuiltin }
 
 func (s *ServerOptions) concurrency() int64 {
 	if s == nil || s.Concurrency < 1 {


### PR DESCRIPTION
As mentioned in the comment, according to the JSON-RPC specification:

> The absence of expected names MAY result in an error being generated.

The option therefore allows the server to choose between a strict or tolerant behaviour.

--- 

To put this into the context of a real use case:

I'm trying to build a Language Server with this library while also using https://github.com/sourcegraph/go-lsp for the structs. These structs aren't always up to date though and so the client which technically implements the same protocol (likely using a different LSP library and even a different language) may be "more complete". I'd like the Language Server to be tolerant of this.