### PR TITLE
Allow header framed messages to omit Content-Type.

### DIFF
--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -164,7 +164,9 @@ func TestHeaderTypeMismatch(t *testing.T) {
 		ok      func(error) bool
 	}{
 		// With a content type provided, no error is reported.
+		// Order of headers and extra headers should not affect this.
 		{"Content-Type: text/plain\r\nContent-Length: 3\r\n\r\nfoo", noError},
+		{"Extra: ok\r\nContent-Length: 4\r\nContent-Type: text/plain\r\n\r\nquux", noError},
 
 		// With a content type omitted, a sentinel error is reported.
 		{"Content-Length: 5\r\n\r\nabcde", func(err error) bool {

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -168,6 +168,12 @@ func TestHeaderTypeMismatch(t *testing.T) {
 		{"Content-Type: text/plain\r\nContent-Length: 3\r\n\r\nfoo", noError},
 		{"Extra: ok\r\nContent-Length: 4\r\nContent-Type: text/plain\r\n\r\nquux", noError},
 
+		// With a content type provided, report an error if it doesn't match.
+		{"Content-Length: 2\r\nContent-Type: application/json\r\n\r\nno", func(err error) bool {
+			v, ok := err.(*ContentTypeMismatchError)
+			return ok && v.Got == "application/json" && v.Want == "text/plain"
+		}},
+
 		// With a content type omitted, a sentinel error is reported.
 		{"Content-Length: 5\r\n\r\nabcde", func(err error) bool {
 			v, ok := err.(*ContentTypeMismatchError)


### PR DESCRIPTION
Rework the Header framing, moving the existing implementation to StrictHeader. The latter still reports an error for content-type mismatches, but does so in a way that permits the caller to detect it.

The Header framing is now a light wrapper for StrictHeader that filters out these mismatches. The LSP framing now permits the sender to omit the content-type field without reporting an error.

Addresses #4.