### PR TITLE
go.mod: Bump requirement to Go 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,4 @@ require (
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 )
 
-go 1.12
+go 1.13


### PR DESCRIPTION
This is mostly to make consumer's Go tooling to issue a helpful message about version requirement, rather than just compilation errors.

Related to https://github.com/creachadair/jrpc2/commit/81dd53f1d58b55d5b1c0a3c8ccc5cb2c818c3a0c and https://github.com/creachadair/jrpc2/commit/3ce3f1c20ee71a8efe0d3e3aeafe4711852c9545