### PR TITLE
Add hooks for structured RPC logging

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -194,8 +194,9 @@ type RPCLogger interface {
 	// Called for each request received prior to invoking its handler.
 	LogRequest(ctx context.Context, req *Request)
 
-	// Called for each response produced by a handler. The inbound request can
-	// be recovered from the context using jrpc2.InboundRequest.
+	// Called for each response produced by a handler, immediately prior to
+	// sending it back to the client. The inbound request can be recovered from
+	// the context using jrpc2.InboundRequest.
 	LogResponse(ctx context.Context, rsp *Response)
 }
 


### PR DESCRIPTION
Add a server option to provide callbacks for each request received from the client and its corresponding response (if any). This supports debugging and also RPC capture for replay testing.

Addresses #2.

