### PR TITLE
ServerOptions: Add support for OnStop hook

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -53,6 +53,10 @@ type ServerOptions struct {
 	// the request fails with that error without invoking the handler.
 	CheckRequest func(ctx context.Context, req *Request) error
 
+	// If set, this function is called after server is shut down
+	// to allow for any cleanup if server was not shut down explicitly via Stop()
+	OnStop onStopFunc
+
 	// If set, use this value to record server metrics. All servers created
 	// from the same options will share the same metrics collector.  If none is
 	// set, an empty collector will be created for each new server.
@@ -121,6 +125,13 @@ func (s *ServerOptions) rpcLog() RPCLogger {
 		return nullRPCLogger{}
 	}
 	return s.RPCLog
+}
+
+func (s *ServerOptions) onStopFunc() onStopFunc {
+	if s == nil || s.OnStop == nil {
+		return func(error) {}
+	}
+	return s.OnStop
 }
 
 // ClientOptions control the behaviour of a client created by NewClient.


### PR DESCRIPTION
While in many cases it's probably desirable to treat EOF and channel closure the same way as graceful server shutdown (via `Server.Stop()`), there can be cases when it's not.

Example: The Language Server Protocol specifically declares that clients should send `shutdown`/`exit`, rather than just `EOF`. Having such hook would allow the server to differentiate between clients which follow the spec and ones which do not.

More importantly this makes it possible to stop any other operations that may be running outside the context of the server - e.g. Go routines which were started as part of an RPC request but intentionally are _not_ cancellable within the context of that request (e.g. because the operation may be time-consuming and its result doesn't affect the response, so there is no point in delaying the response).

### Example usage

```go
func main() {
	srvCtx, stopFunc := context.WithCancel(context.Background())

	opts := &jrpc2.ServerOptions{}
	opts.OnStop = func(err error) {
		if err == io.EOF || channel.IsErrClosing(err) {
			log.Println("server stopped unexpectedly:", err)
			stopFunc()
		}
	}

	ch := channel.LSP(os.Stdin, os.Stdout)
	srv := jrpc2.NewServer(handlerMap(stopFunc), opts).Start(ch)

	go func() {
		err := srv.Wait()
		if err != nil {
			log.Println("failed to start server:", err)
			stopFunc()
		}
	}()

	select {
	case <-srvCtx.Done():
		srv.Stop()
	}
}

func handlerMap(stopFunc context.CancelFunc) jrpc2.Assigner {
	return handler.Map{
		"shutdown": handler.New(func(ctx context.Context) error {
			log.Println("shutting down gracefully...")
			stopFunc()
			return nil
		}),
	}
}
```
