### PR TITLE
Report what extra fields are passed in error

### DIFF
--- a/base.go
+++ b/base.go
@@ -294,7 +294,7 @@ func (j *jrequest) parseJSON(data []byte) error {
 
 	// Report an error for extraneous fields.
 	if len(extra) != 0 {
-		j.fail(code.InvalidRequest, "extra fields in request")
+		j.err = DataErrorf(code.InvalidRequest, extra, "extra fields in request")
 	}
 	return nil
 }

--- a/jrpc2_test.go
+++ b/jrpc2_test.go
@@ -561,7 +561,7 @@ func TestOtherClient(t *testing.T) {
 
 		// Extra fields on an otherwise-correct request.
 		{`{"jsonrpc":"2.0","id": 7, "method": "Z", "params":[], "bogus":true}`,
-			`{"jsonrpc":"2.0","id":7,"error":{"code":-32600,"message":"extra fields in request"}}`},
+			`{"jsonrpc":"2.0","id":7,"error":{"code":-32600,"message":"extra fields in request","data":["bogus"]}}`},
 
 		// An empty batch request should report a single error object.
 		{`[]`, `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"empty request batch"}}`},


### PR DESCRIPTION
I was implementing slightly more complex I/O logic (partially to make server mock-able) and I managed to mistakenly mix up client and server writers and readers and it wasn't clear to me immediately that the server was processing its own responses as requests until I dug deeper and exposed some more details in the error message.

I feel this could save some other people valuable debugging time.