### PR TITLE
server: Allow caller to distinguish shutdown from close

### DIFF
--- a/server.go
+++ b/server.go
@@ -364,6 +364,12 @@ type ServerStatus struct {
 	Stopped bool  // reports whether Stop was called
 }
 
+// Success reports whether the server exited without error.
+func (s ServerStatus) Success() bool { return s.Err == nil }
+
+// Closed reports whether the server exited due to a channel close.
+func (s ServerStatus) Closed() bool { return s.Err == nil && !s.Stopped }
+
 // WaitStatus blocks until the server terminates, and returns the resulting
 // status. After WaitStatus returns, whether or not there was an error, it is
 // safe to call s.Start again to restart the server with a fresh channel.

--- a/server.go
+++ b/server.go
@@ -360,15 +360,19 @@ func (s *Server) Stop() {
 
 // ServerStatus describes the status of a stopped server.
 type ServerStatus struct {
-	Err     error // the error that caused the server to stop (nil on success)
-	Stopped bool  // reports whether Stop was called
+	Err error // the error that caused the server to stop (nil on success)
+
+	stopped bool // whether Stop was called
 }
 
 // Success reports whether the server exited without error.
 func (s ServerStatus) Success() bool { return s.Err == nil }
 
+// Stopped reports whether the server exited due to Stop being called.
+func (s ServerStatus) Stopped() bool { return s.Err == nil && s.stopped }
+
 // Closed reports whether the server exited due to a channel close.
-func (s ServerStatus) Closed() bool { return s.Err == nil && !s.Stopped }
+func (s ServerStatus) Closed() bool { return s.Err == nil && !s.stopped }
 
 // WaitStatus blocks until the server terminates, and returns the resulting
 // status. After WaitStatus returns, whether or not there was an error, it is
@@ -384,7 +388,7 @@ func (s *Server) WaitStatus() ServerStatus {
 	if s.err == io.EOF || channel.IsErrClosing(s.err) || s.err == errServerStopped {
 		exitErr = nil
 	}
-	return ServerStatus{Err: exitErr, Stopped: s.err == errServerStopped}
+	return ServerStatus{Err: exitErr, stopped: s.err == errServerStopped}
 }
 
 // Wait blocks until the server terminates and returns the resulting error.

--- a/server.go
+++ b/server.go
@@ -358,21 +358,32 @@ func (s *Server) Stop() {
 	s.stop(errServerStopped)
 }
 
-// Wait blocks until the connection terminates and returns the resulting error.
-// After Wait returns, whether or not there was an error, it is safe to call
-// s.Start again to restart the server with a fresh channel.
-func (s *Server) Wait() error {
+// ServerStatus describes the status of a stopped server.
+type ServerStatus struct {
+	Err     error // the error that caused the server to stop (nil on success)
+	Stopped bool  // reports whether Stop was called
+}
+
+// WaitStatus blocks until the server terminates, and returns the resulting
+// status. After WaitStatus returns, whether or not there was an error, it is
+// safe to call s.Start again to restart the server with a fresh channel.
+func (s *Server) WaitStatus() ServerStatus {
 	s.wg.Wait()
 	// Sanity check.
 	if s.inq.Len() != 0 {
 		panic("s.inq is not empty at shutdown")
 	}
+	exitErr := s.err
 	// Don't remark on a closed channel or EOF as a noteworthy failure.
 	if s.err == io.EOF || channel.IsErrClosing(s.err) || s.err == errServerStopped {
-		return nil
+		exitErr = nil
 	}
-	return s.err
+	return ServerStatus{Err: exitErr, Stopped: s.err == errServerStopped}
 }
+
+// Wait blocks until the server terminates and returns the resulting error.
+// It is equivalent to s.WaitStatus().Err.
+func (s *Server) Wait() error { return s.WaitStatus().Err }
 
 // stop shuts down the connection and records err as its final state.  The
 // caller must hold s.mu. If multiple callers invoke stop, only the first will


### PR DESCRIPTION
Addresses #11. The Wait method filters out normal channel close errors, along
with explicit calls to Stop.  This is usually what you want, but means the
caller can't distinguish explicit shutdown from channel closes.

Add a WaitStatus method that includes more detail, and re-implement Wait in
terms of it.