### PR TITLE
server: add a one-shot service wrapper

### DIFF
--- a/server/simple.go
+++ b/server/simple.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"errors"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/channel"
+)
+
+// A Simple server manages execution of a server for a single service instance.
+type Simple struct {
+	server *jrpc2.Server
+	svc    Service
+	opts   *jrpc2.ServerOptions
+}
+
+// NewSimple constructs a new, unstarted *Simple instance for the given
+// service.  When run, the server will use the specified options.
+func NewSimple(svc Service, opts *jrpc2.ServerOptions) *Simple {
+	return &Simple{svc: svc, opts: opts}
+}
+
+// Run starts a server on the given channel, and blocks until it returns.  The
+// server exit status is reported to the service, and the error value returned.
+func (s *Simple) Run(ch channel.Channel) error {
+	if s.server != nil {
+		return errors.New("server is already running")
+	}
+	assigner, err := s.svc.Assigner()
+	if err != nil {
+		return err
+	}
+	s.server = jrpc2.NewServer(assigner, s.opts).Start(ch)
+	return s.wait()
+}
+
+// wait for the server to exit and report its status back to the service.
+// Reset the wrapper so it can be re-used.
+func (s *Simple) wait() error {
+	stat := s.server.WaitStatus()
+	s.svc.Finish(stat)
+	s.server = nil // reset
+	return stat.Err
+}
+
+// Stop shuts down the server instance, waits for it to complete, and reports
+// the result from its Wait method. It is safe to call Stop even if the server
+// is not running; it will report nil.
+func (s *Simple) Stop() error {
+	if s.server == nil {
+		return nil
+	}
+	s.server.Stop()
+	return s.wait()
+}

--- a/server/simple.go
+++ b/server/simple.go
@@ -22,6 +22,9 @@ func NewSimple(svc Service, opts *jrpc2.ServerOptions) *Simple {
 
 // Run starts a server on the given channel, and blocks until it returns.  The
 // server exit status is reported to the service, and the error value returned.
+//
+// If the caller does not need the error value and does not want to wait for
+// the server to complete, call Run in a goroutine.
 func (s *Simple) Run(ch channel.Channel) error {
 	if s.server != nil {
 		return errors.New("server is already running")

--- a/server/simple.go
+++ b/server/simple.go
@@ -22,6 +22,7 @@ func NewSimple(svc Service, opts *jrpc2.ServerOptions) *Simple {
 
 // Run starts a server on the given channel, and blocks until it returns.  The
 // server exit status is reported to the service, and the error value returned.
+// Once Run returns, it can be run again with a new channel.
 //
 // If the caller does not need the error value and does not want to wait for
 // the server to complete, call Run in a goroutine.
@@ -48,7 +49,8 @@ func (s *Simple) wait() error {
 
 // Stop shuts down the server instance, waits for it to complete, and reports
 // the result from its Wait method. It is safe to call Stop even if the server
-// is not running; it will report nil.
+// is not running; it will report nil. Once Stop returns it is safe to run the
+// server again with a new channel.
 func (s *Simple) Stop() error {
 	if s.server == nil {
 		return nil

--- a/server/simple_test.go
+++ b/server/simple_test.go
@@ -1,0 +1,7 @@
+package server_test
+
+import "testing"
+
+func TestThings(t *testing.T) {
+	t.Fail()
+}

--- a/server/simple_test.go
+++ b/server/simple_test.go
@@ -1,7 +1,63 @@
 package server_test
 
-import "testing"
+import (
+	"context"
+	"testing"
 
-func TestThings(t *testing.T) {
-	t.Fail()
+	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/channel"
+	"github.com/creachadair/jrpc2/handler"
+	"github.com/creachadair/jrpc2/server"
+)
+
+type testService struct {
+	assigner                   jrpc2.Assigner
+	assignCalled, finishCalled bool
+	stat                       jrpc2.ServerStatus
+}
+
+func (t *testService) Assigner() (jrpc2.Assigner, error) {
+	t.assignCalled = true
+	return t.assigner, nil
+}
+
+func (t *testService) Finish(stat jrpc2.ServerStatus) {
+	t.finishCalled = true
+	t.stat = stat
+}
+
+func TestSimple(t *testing.T) {
+	svc := &testService{assigner: handler.Map{
+		"Test": handler.New(func(ctx context.Context) string {
+			return "OK"
+		}),
+	}}
+	cpipe, spipe := channel.Direct()
+	cdone := make(chan struct{})
+	var result string
+	go func() {
+		defer close(cdone)
+		cli := jrpc2.NewClient(cpipe, nil)
+		defer cli.Close()
+		if err := cli.CallResult(context.Background(), "Test", nil, &result); err != nil {
+			t.Errorf("Call Test failed: %v", err)
+		}
+	}()
+
+	srv := server.NewSimple(svc, nil)
+	if err := srv.Run(spipe); err != nil {
+		t.Errorf("Server failed: %v", err)
+	}
+	if result != "OK" {
+		t.Errorf("Call result: got %q, want %q", result, "OK")
+	}
+	if !svc.assignCalled {
+		t.Error("Assigner was not called")
+	}
+	if !svc.finishCalled {
+		t.Error("Finish was not called")
+	}
+	if svc.stat.Err != nil {
+		t.Errorf("Server status: unexpected error: %+v", svc.stat)
+	}
 }


### PR DESCRIPTION
Inspired by this comment thread: https://github.com/creachadair/jrpc2/pull/14#pullrequestreview-378053953

There are a couple differences worth noting here from the outline in that thread:

- Rather than exposing Wait and WaitStatus, this implementation runs the server to completion. A caller that doesn't want to wait can run it in a goroutine (`go s.Run(ch)`) and then the service alone is responsible for handling the return status.
- No work is done until the server is started, so that it's safe to abandon a constructed wrapper without orphaning resources the service may have allocated.