### PR TITLE
Add a barrier constraining execution order for notifications.

### DIFF
--- a/base.go
+++ b/base.go
@@ -322,6 +322,9 @@ func (j *jmessage) parseJSON(data []byte) error {
 // isRequestOrNotification reports whether j is a request or notification.
 func (j *jmessage) isRequestOrNotification() bool { return j.E == nil && j.R == nil && j.M != "" }
 
+// isNotification reports whether j is a notification
+func (j *jmessage) isNotification() bool { return j.isRequestOrNotification() && fixID(j.ID) == nil }
+
 type jerror struct {
 	C int32           `json:"code"`
 	M string          `json:"message,omitempty"`

--- a/doc.go
+++ b/doc.go
@@ -185,6 +185,21 @@ name on the first period ("."), and you may nest ServiceMaps more deeply if you
 require a more complex hierarchy.
 
 
+Concurrency
+
+A Server processes requests concurrently, up to the Concurrency limit given in
+its ServerOptions. Two requests (calls or notifications) are concurrent if they
+arrive as part of the same batch. In addition, two calls are concurrent if the
+time intervals between the arrival of the request objects and delivery of the
+response objects overlap.
+
+The server may issue concurrent requests to their handlers in any order.
+Otherwise, requests are processed in order of arrival. Notifications, in
+particular, can only be concurrent with other notifications in the same batch.
+This ensures a client that sends a notification can be sure its notification
+was fully processed before any subsequent calls are issued.
+
+
 Non-Standard Extension Methods
 
 By default a jrpc2.Server exports the following built-in non-standard extension

--- a/opts.go
+++ b/opts.go
@@ -38,7 +38,8 @@ type ServerOptions struct {
 	DisableBuiltin bool
 
 	// Allows up to the specified number of goroutines to execute concurrently
-	// in request handlers. A value less than 1 uses runtime.NumCPU().
+	// in request handlers. A value less than 1 uses runtime.NumCPU().  Note
+	// that this setting does not constrain order of issue.
 	Concurrency int
 
 	// If set, this function is called with the method name and encoded request

--- a/server.go
+++ b/server.go
@@ -202,10 +202,10 @@ func (s *Server) dispatch(next jmessages, ch channel.Sender) func() error {
 			wg.Add(1)
 			run := func() {
 				defer wg.Done()
-				t.val, t.err = s.invoke(t.ctx, t.m, t.hreq)
 				if t.hreq.IsNotification() {
-					s.nbar.Done()
+					defer s.nbar.Done()
 				}
+				t.val, t.err = s.invoke(t.ctx, t.m, t.hreq)
 			}
 			if i < last {
 				go run()

--- a/server.go
+++ b/server.go
@@ -24,7 +24,6 @@ type Server struct {
 	wg      sync.WaitGroup      // ready when workers are done at shutdown time
 	mux     Assigner            // associates method names with handlers
 	sem     *semaphore.Weighted // bounds concurrent execution (default 1)
-	nbar    sync.WaitGroup      // notification barrier (see the dispatch method)
 	allow1  bool                // allow v1 requests with no version marker
 	allowP  bool                // allow server notifications to the client
 	log     logger              // write debug logs here
@@ -38,6 +37,7 @@ type Server struct {
 
 	mu *sync.Mutex // protects the fields below
 
+	nbar sync.WaitGroup  // notification barrier (see the dispatch method)
 	err  error           // error from a previous operation
 	work *sync.Cond      // for signaling message availability
 	inq  *list.List      // inbound requests awaiting processing

--- a/server.go
+++ b/server.go
@@ -433,7 +433,7 @@ func (s *Server) stop(err error) {
 	// Remove any pending requests from the queue, but retain notifications.
 	// The server will process pending notifications before giving up.
 	//
-	// TODO(@creachdair): We need better tests for this behaviour.
+	// TODO(@creachadair): We need better tests for this behaviour.
 	var keep jmessages
 	for cur := s.inq.Front(); cur != nil; cur = s.inq.Front() {
 		for _, req := range cur.Value.(jmessages) {

--- a/server.go
+++ b/server.go
@@ -24,6 +24,7 @@ type Server struct {
 	wg      sync.WaitGroup      // ready when workers are done at shutdown time
 	mux     Assigner            // associates method names with handlers
 	sem     *semaphore.Weighted // bounds concurrent execution (default 1)
+	nbar    sync.WaitGroup      // notification barrier (see the dispatch method)
 	allow1  bool                // allow v1 requests with no version marker
 	allowP  bool                // allow server notifications to the client
 	log     logger              // write debug logs here
@@ -171,35 +172,50 @@ func (s *Server) nextRequest() (func() error, error) {
 // dispatch constructs a function that invokes each of the specified tasks.
 // The caller must hold s.mu when calling dispatch, but the returned function
 // should be executed outside the lock to wait for the handlers to return.
+//
+// dispatch blocks until any notification received prior to this batch has
+// completed, to ensure that notifications are processed in a partial order
+// that respects order of receipt. Notifications within a batch are handled
+// concurrently.
 func (s *Server) dispatch(next jmessages, ch channel.Sender) func() error {
 	// Resolve all the task handlers or record errors.
 	start := time.Now()
 	tasks := s.checkAndAssign(next)
+	last := len(tasks) - 1
 
-	n := len(tasks)
-	last := tasks[n-1]
+	// s.nbar counts the number of notifications that have been issued and are
+	// not yet complete. Before issuing any tasks in this batch, wait for all
+	// such notifications to complete, and update the barrier with the number in
+	// this batch. This update must happen under s.mu, so that multiple batches
+	// do not race on Wait/Add.
+	s.nbar.Wait()
+	s.nbar.Add(tasks.numValidNotifications())
 
-	// If there are multiple tasks, start goroutines to handle all but the
-	// last. The last is handled directly, to avoid spinning up a separate
-	// goroutine for a single task.
-	var wg sync.WaitGroup
-	for _, t := range tasks[:n-1] {
-		if t.err != nil {
-			continue // nothing to do here; this task has already failed
-		}
-		wg.Add(1)
-		go func(t *task) {
-			defer wg.Done()
-			t.val, t.err = s.invoke(t.ctx, t.m, t.hreq)
-		}(t)
-	}
-
-	// Wait for all the handlers to return, then deliver any responses.
 	return func() error {
-		wg.Wait()
-		if last.err == nil {
-			last.val, last.err = s.invoke(last.ctx, last.m, last.hreq)
+		var wg sync.WaitGroup
+		for i, t := range tasks {
+			if t.err != nil {
+				continue // nothing to do here; this task has already failed
+			}
+			t := t
+
+			wg.Add(1)
+			run := func() {
+				defer wg.Done()
+				t.val, t.err = s.invoke(t.ctx, t.m, t.hreq)
+				if t.hreq.IsNotification() {
+					s.nbar.Done()
+				}
+			}
+			if i < last {
+				go run()
+			} else {
+				run()
+			}
 		}
+
+		// Wait for all the handlers to return, then deliver any responses.
+		wg.Wait()
 		return s.deliver(tasks.responses(s.rpcLog), ch, time.Since(start))
 	}
 }
@@ -419,7 +435,7 @@ func (s *Server) stop(err error) {
 	for cur := s.inq.Front(); cur != nil; cur = cur.Next() {
 		var keep jmessages
 		for _, req := range cur.Value.(jmessages) {
-			if req.ID == nil {
+			if req.isNotification() {
 				keep = append(keep, req)
 				s.log("Retaining notification %p", req)
 			} else {
@@ -610,4 +626,15 @@ func (ts tasks) responses(rpcLog RPCLogger) jmessages {
 		rsps = append(rsps, rsp)
 	}
 	return rsps
+}
+
+// numValidNotifications reports the number of elements in ts that are
+// syntactically valid notifications.
+func (ts tasks) numValidNotifications() (n int) {
+	for _, t := range ts {
+		if t.err == nil && t.hreq.IsNotification() {
+			n++
+		}
+	}
+	return
 }


### PR DESCRIPTION
An attempt to address #20.
    
When issuing a batch of requests, keep track of the number that are valid notifications, and do not issue to any handler for the batch until all notifications received in previous batches have completed.
    
This ensures a sensible partial order on notifications. Multiple notifications in a single batch can still be executed in parallel, but notifications across batches are no longer concurrent.

TODO before merging:
- [x] Verify that this change fixes #20 (see https://github.com/hashicorp/terraform-ls/issues/161#issuecomment-658469840)
- [ ] Update the documentation for this new behaviour.
