### PR TITLE
Remove use of lock in cancelRequests

### DIFF
--- a/special.go
+++ b/special.go
@@ -27,8 +27,6 @@ func (s *Server) handleRPCCancel(ctx context.Context, req *Request) (interface{}
 }
 
 func (s *Server) cancelRequests(ctx context.Context, ids []json.RawMessage) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
 	for _, raw := range ids {
 		id := string(raw)
 		if s.cancel(id) {


### PR DESCRIPTION
Found via ad hoc testing/repro. We are able to trigger a race where the lock acquired in the `cancelRequests` handler is deadlocked. The reason for deadlock is not fully traced, but from what I can tell, `s.mu.Lock` is not needed when calling `s.cancel`. ~This PR may need to create~ I will make it concurrent safe lookup of the `s.used` map with https://golang.org/pkg/sync/#Map.

I am new to this codebase so as I said I'm unsure why the code deadlocks (I wish I could offer concrete repro steps, but it involves the terraform language server/vscode plugin and spamming format on save requests), it seems like the lock is acquired in `nextRequest` but not freed by the time it hits `cancelRequests`.

Perhaps something about these lines?
https://github.com/creachadair/jrpc2/blob/master/server.go#L218-L222

But I think it's possible calling the lock in a request handler (given a lock is acquired in `nextRequest`) is a mistake (which is why I removed it in this PR)?

Relates https://github.com/hashicorp/terraform-ls/issues/258