### PR TITLE
Fix a deadlock between handlers and server.

### DIFF
--- a/regression_test.go
+++ b/regression_test.go
@@ -13,12 +13,12 @@ import (
 // Verify that a notification handler will not deadlock with the dispatcher on
 // holding the server lock. See: https://github.com/creachadair/jrpc2/pull/26
 func TestLockRaceRegression(t *testing.T) {
-	done := make(chan struct{})
+	hdone := make(chan struct{})
 	local := server.NewLocal(handler.Map{
 		// Do some busy-work and then try to get the server lock, in this case
 		// via the CancelRequest helper.
 		"Kill": handler.New(func(ctx context.Context, req *jrpc2.Request) error {
-			defer close(done) // signal we passed the deadlock point
+			defer close(hdone) // signal we passed the deadlock point
 
 			var id string
 			if err := req.UnmarshalParams(&handler.Args{&id}); err != nil {
@@ -38,19 +38,13 @@ func TestLockRaceRegression(t *testing.T) {
 
 	ctx := context.Background()
 	local.Client.Notify(ctx, "Kill", handler.Args{"1"})
-	go func() {
-		rsp, err := local.Client.Call(ctx, "Stall", nil)
-		if err != nil {
-			t.Logf("Call reported an error [expected]: %v", err)
-		} else {
-			t.Errorf("Call unexpectedly succeeded: %s", rsp.ResultString())
-		}
-	}()
+
+	go local.Client.Call(ctx, "Stall", nil)
 
 	select {
 	case <-time.After(10 * time.Second):
 		t.Fatal("Notification handler is probably deadlocked")
-	case <-done:
+	case <-hdone:
 		t.Log("Notification handler completed successfully")
 	}
 }

--- a/regression_test.go
+++ b/regression_test.go
@@ -1,0 +1,56 @@
+package jrpc2_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/handler"
+	"github.com/creachadair/jrpc2/server"
+)
+
+// Verify that a notification handler will not deadlock with the dispatcher on
+// holding the server lock. See: https://github.com/creachadair/jrpc2/pull/26
+func TestLockRaceRegression(t *testing.T) {
+	done := make(chan struct{})
+	local := server.NewLocal(handler.Map{
+		// Do some busy-work and then try to get the server lock, in this case
+		// via the CancelRequest helper.
+		"Kill": handler.New(func(ctx context.Context, req *jrpc2.Request) error {
+			defer close(done) // signal we passed the deadlock point
+
+			var id string
+			if err := req.UnmarshalParams(&handler.Args{&id}); err != nil {
+				return err
+			}
+			jrpc2.CancelRequest(ctx, id)
+			return nil
+		}),
+
+		// Block indefinitely, just to give the dispatcher something to do.
+		"Stall": handler.New(func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}),
+	}, nil)
+	defer local.Close()
+
+	ctx := context.Background()
+	local.Client.Notify(ctx, "Kill", handler.Args{"1"})
+	go func() {
+		rsp, err := local.Client.Call(ctx, "Stall", nil)
+		if err != nil {
+			t.Logf("Call reported an error [expected]: %v", err)
+		} else {
+			t.Errorf("Call unexpectedly succeeded: %s", rsp.ResultString())
+		}
+	}()
+
+	select {
+	case <-time.After(10 * time.Second):
+		t.Fatal("Notification handler is probably deadlocked")
+	case <-done:
+		t.Log("Notification handler completed successfully")
+	}
+}

--- a/regression_test.go
+++ b/regression_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Verify that a notification handler will not deadlock with the dispatcher on
-// holding the server lock. See: https://github.com/creachadair/jrpc2/pull/26
+// holding the server lock. See: https://github.com/creachadair/jrpc2/issues/27
 func TestLockRaceRegression(t *testing.T) {
 	hdone := make(chan struct{})
 	local := server.NewLocal(handler.Map{

--- a/server.go
+++ b/server.go
@@ -177,6 +177,20 @@ func (s *Server) nextRequest() (func() error, error) {
 	return s.dispatch(next, ch), nil
 }
 
+// waitForBarrier blocks until all notification handlers that have been issued
+// have completed, then adds n to the barrier.
+//
+// The caller must hold s.mu, but the lock is released during the wait to avert
+// a deadlock with handlers calling back into the server.  See the discussion
+// on #26.  s.nbar counts the number of notifications that have been issued and
+// are not yet complete.
+func (s *Server) waitForBarrier(n int) {
+	s.mu.Unlock()
+	defer s.mu.Lock()
+	s.nbar.Wait()
+	s.nbar.Add(n)
+}
+
 // dispatch constructs a function that invokes each of the specified tasks.
 // The caller must hold s.mu when calling dispatch, but the returned function
 // should be executed outside the lock to wait for the handlers to return.
@@ -191,13 +205,8 @@ func (s *Server) dispatch(next jmessages, ch channel.Sender) func() error {
 	tasks := s.checkAndAssign(next)
 	last := len(tasks) - 1
 
-	// s.nbar counts the number of notifications that have been issued and are
-	// not yet complete. Before issuing any tasks in this batch, wait for all
-	// such notifications to complete, and update the barrier with the number in
-	// this batch. This update must happen under s.mu, so that multiple batches
-	// do not race on Wait/Add.
-	s.nbar.Wait()
-	s.nbar.Add(tasks.numValidNotifications())
+	// Ensure all notifications already issued have completed; see #24.
+	s.waitForBarrier(tasks.numValidNotifications())
 
 	return func() error {
 		var wg sync.WaitGroup

--- a/server.go
+++ b/server.go
@@ -181,9 +181,9 @@ func (s *Server) nextRequest() (func() error, error) {
 // have completed, then adds n to the barrier.
 //
 // The caller must hold s.mu, but the lock is released during the wait to avert
-// a deadlock with handlers calling back into the server.  See the discussion
-// on #26.  s.nbar counts the number of notifications that have been issued and
-// are not yet complete.
+// a deadlock with handlers calling back into the server.  See #27.
+// s.nbar counts the number of notifications that have been issued and are not
+// yet complete.
 func (s *Server) waitForBarrier(n int) {
 	s.mu.Unlock()
 	defer s.mu.Lock()


### PR DESCRIPTION
Fixes #27. Since #24, the server holds its lock during dispatch to wait for previously-issued notifications to settle. This is necessary to ensure a sensible order of operations; however, it interacts badly with a notification handler that uses the jrpc2.CancelRequest helper: That function itself acquires the server lock, and the two (may) deadlock.

To avert this problem, wait on the notification barrier outside the lock. Add a regression test against the original bug.