### PR TITLE
Add a cancellation callback to ClientOptions.

### DIFF
--- a/base.go
+++ b/base.go
@@ -167,7 +167,7 @@ func (r *Response) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// wait blocks until p is complete. It is safe to call this multiple times and
+// wait blocks until r is complete. It is safe to call this multiple times and
 // from concurrent goroutines.
 func (r *Response) wait() {
 	raw, ok := <-r.ch


### PR DESCRIPTION
When set, the new OnCancel callback overrides the client's built-in support for
sending rpc.cancel notifications. The hook can implement the same functionality
or take other actions using the client and the cancelled response.

Related changes:
- Add tests for OnCancel hook handling.
- Fix up some comment typos.