### PR TITLE
Improve handling of unknown fields in parameter structs

### DIFF
--- a/base.go
+++ b/base.go
@@ -84,14 +84,14 @@ func (r *Request) UnmarshalParams(v interface{}) error {
 		*raw = json.RawMessage(string(r.params)) // copy
 		return nil
 	}
-	dec := json.NewDecoder(bytes.NewReader(r.params))
 	if _, ok := v.(strictFielder); ok {
+		dec := json.NewDecoder(bytes.NewReader(r.params))
 		dec.DisallowUnknownFields()
+		if err := dec.Decode(v); err != nil {
+			return Errorf(code.InvalidParams, "invalid parameters: %v", err.Error())
+		}
 	}
-	if err := dec.Decode(v); err != nil {
-		return Errorf(code.InvalidParams, "invalid parameters: %v", err.Error())
-	}
-	return nil
+	return json.Unmarshal(r.params, v)
 }
 
 // ParamString returns the encoded request parameters of r as a string.
@@ -425,7 +425,7 @@ type strictFielder interface {
 // For example:
 //
 //       var obj RequestType
-//       err := req.UnmarshalParams(jrpc2.StrictFields(&obj))
+//       err := req.UnmarshalParams(jrpc2.StrictFields(&obj))`
 //
 func StrictFields(v interface{}) interface{} { return &strict{v: v} }
 

--- a/base.go
+++ b/base.go
@@ -71,8 +71,10 @@ func (r *Request) HasParams() bool { return len(r.params) != 0 }
 // an InvalidParams error.
 //
 // By default, unknown keys are disallowed when unmarshaling into a v of struct
-// type. This can be overridden by implementing an UnknownFields method that
-// returns true, on the concrete type of v.
+// type. This can be overridden by providing a custom implementation of
+// json.Unmarshaler, or by implementing an UnknownFields method that returns
+// true, on the concrete type of v. The jrpc2.NonStrict helper function adapts
+// existing values to the UnknownFielder interface.
 //
 // If v has type *json.RawMessage, decoding cannot fail.
 func (r *Request) UnmarshalParams(v interface{}) error {

--- a/examples_test.go
+++ b/examples_test.go
@@ -114,15 +114,15 @@ func ExampleRequest_UnmarshalParams() {
 		B int `json:"b"`
 	}
 
-	// By default, unmarshaling prohibits unknown fields (here, "c").
-	err = reqs[0].UnmarshalParams(&t)
-	if code.FromError(err) != code.InvalidParams {
-		log.Fatalf("Expected invalid parameters, got: %v", err)
+	// By default, unmarshaling ignores unknown fields (here, "c").
+	if err := reqs[0].UnmarshalParams(&t); err != nil {
+		log.Fatalf("UnmarshalParams: %v", err)
 	}
 
-	// Solution 1: Implement jrpc2.UnknownFielder.
-	if err := reqs[0].UnmarshalParams(jrpc2.NonStrict(&t)); err != nil {
-		log.Fatalf("UnmarshalParams: %v", err)
+	// Solution 1: Use the jrpc2.StrictFields helper.
+	err = reqs[0].UnmarshalParams(jrpc2.StrictFields(&t))
+	if code.FromError(err) != code.InvalidParams {
+		log.Fatalf("UnmarshalParams strict: %v", err)
 	}
 	fmt.Printf("t.A=%d, t.B=%d\n", t.A, t.B)
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -120,7 +120,7 @@ func ExampleRequest_UnmarshalParams() {
 		log.Fatalf("Expected invalid parameters, got: %v", err)
 	}
 
-	// Solution 1: Decode with jrpc2.NonStrict.
+	// Solution 1: Implement jrpc2.UnknownFielder.
 	if err := reqs[0].UnmarshalParams(jrpc2.NonStrict(&t)); err != nil {
 		log.Fatalf("UnmarshalParams: %v", err)
 	}

--- a/internal_test.go
+++ b/internal_test.go
@@ -107,7 +107,7 @@ func TestUnmarshalParams(t *testing.T) {
 		{`{"jsonrpc":"2.0", "id":5, "method":"Z", "params":{"x":23, "y":true}}`,
 			xy{X: 23, Y: true}, `{"x":23, "y":true}`, code.NoError},
 		{`{"jsonrpc":"2.0", "id":6, "method":"Z", "params":{"x":23, "z":"wat"}}`,
-			xy{}, `{"x":23, "z":"wat"}`, code.InvalidParams},
+			xy{X: 23}, `{"x":23, "z":"wat"}`, code.NoError},
 	}
 	for _, test := range tests {
 		req, err := ParseRequests([]byte(test.input))

--- a/jrpc2_test.go
+++ b/jrpc2_test.go
@@ -1065,7 +1065,7 @@ func (buggyChannel) Send([]byte) error       { panic("should not be called") }
 func (b buggyChannel) Recv() ([]byte, error) { return []byte(b.data), b.err }
 func (buggyChannel) Close() error            { return nil }
 
-func TestNonStrict(t *testing.T) {
+func TestStrictFields(t *testing.T) {
 	type other struct {
 		C bool `json:"charlie"`
 	}
@@ -1078,12 +1078,12 @@ func TestNonStrict(t *testing.T) {
 		"Test": handler.New(func(ctx context.Context, req *jrpc2.Request) error {
 			var ps, qs params
 
-			if err := req.UnmarshalParams(&ps); err == nil {
+			if err := req.UnmarshalParams(jrpc2.StrictFields(&ps)); err == nil {
 				t.Errorf("Unmarshal strict: got %+v, want error", ps)
 			}
 
-			if err := req.UnmarshalParams(jrpc2.NonStrict(&qs)); err != nil {
-				t.Errorf("Unmarshal non-strict: unexpected error: %v", err)
+			if err := req.UnmarshalParams(&qs); err != nil {
+				t.Errorf("Unmarshal non-strict (default): unexpected error: %v", err)
 			} else {
 				t.Logf("Parameters OK: %+v", qs)
 			}


### PR DESCRIPTION
Fixes #31.

Commit 78545e2a disallowed unknown struct fields when unmarshaling parameters. The check could be bypassed by implementing the `json.Unmarshaler` interface, but the need to do so causes friction for implementations of LSP, which has a loose and rapidly-changing schema (see #5, #31).

This changes the default back to ignoring unknown fields, and adds a new optional interface to re-enable strict checking without a custom unmarshaler.

N.B.: This is a breaking API change.