### PR TITLE
Fix request validation checks for push calls.

### DIFF
--- a/jrpc2_test.go
+++ b/jrpc2_test.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -730,12 +728,8 @@ func TestPushCall(t *testing.T) {
 			return nil
 		}),
 	}, &server.LocalOptions{
-		Server: &jrpc2.ServerOptions{
-			AllowPush: true,
-			Logger:    log.New(os.Stderr, "[server] ", log.LstdFlags),
-		},
+		Server: &jrpc2.ServerOptions{AllowPush: true},
 		Client: &jrpc2.ClientOptions{
-			Logger: log.New(os.Stderr, "[client] ", log.LstdFlags),
 			OnCallback: func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
 				t.Logf("OnCallback invoked for method %q", req.Method())
 				switch req.Method() {


### PR DESCRIPTION
Prior to this change, the server checked the ID of an inbound request before
checking whether it is a callback response. This could result in a spurious
error if the callback happened to use the same ID as an in-flight request.

Update the tests to ensure they tickle this case, and fix the order of checks
so that we do not check for duplicate IDs until AFTER filtering matches of a
push response.

Fixes #36.