### PR TITLE
Add a function to expose a Server to its handlers.

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -2,7 +2,6 @@ package jrpc2
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 
 	"github.com/creachadair/jrpc2/metrics"
@@ -52,10 +51,7 @@ func PushCall(ctx context.Context, method string, params interface{}) (*Response
 // CancelRequest requests the server associated with ctx to cancel the pending
 // or in-flight request with the specified ID.  If no request exists with that
 // ID, this is a no-op without error.
-func CancelRequest(ctx context.Context, id string) {
-	s := ctx.Value(serverKey{}).(*Server)
-	s.cancelRequests(ctx, []json.RawMessage{json.RawMessage(id)})
-}
+func CancelRequest(ctx context.Context, id string) { ServerFromContext(ctx).CancelRequest(id) }
 
 // ServerFromContext returns the server associated with the given context.
 // This will be populated on the context passed to request handlers.

--- a/ctx.go
+++ b/ctx.go
@@ -37,11 +37,7 @@ type inboundRequestKey struct{}
 // passed to the handler by *jrpc2.Server will support notifications if the
 // server was constructed with the AllowPush option set true.
 func PushNotify(ctx context.Context, method string, params interface{}) error {
-	s := ctx.Value(serverKey{}).(*Server)
-	if !s.allowP {
-		return ErrPushUnsupported
-	}
-	return s.Notify(ctx, method, params)
+	return ctx.Value(serverKey{}).(*Server).Notify(ctx, method, params)
 }
 
 // PushCall posts a server call to the client. If ctx does not contain a server
@@ -52,11 +48,7 @@ func PushNotify(ctx context.Context, method string, params interface{}) error {
 // A successful callback reports a nil error and a non-nil response. Errors
 // returned by the client have concrete type *jrpc2.Error.
 func PushCall(ctx context.Context, method string, params interface{}) (*Response, error) {
-	s := ctx.Value(serverKey{}).(*Server)
-	if !s.allowP {
-		return nil, ErrPushUnsupported
-	}
-	return s.Callback(ctx, method, params)
+	return ctx.Value(serverKey{}).(*Server).Callback(ctx, method, params)
 }
 
 // CancelRequest requests the server associated with ctx to cancel the pending

--- a/ctx.go
+++ b/ctx.go
@@ -11,9 +11,7 @@ import (
 // ServerMetrics returns the server metrics collector associated with the given
 // context, or nil if ctx does not have a collector attached.  The context
 // passed to a handler by *jrpc2.Server will include this value.
-func ServerMetrics(ctx context.Context) *metrics.M {
-	return ctx.Value(serverKey{}).(*Server).metrics
-}
+func ServerMetrics(ctx context.Context) *metrics.M { return ServerFromContext(ctx).metrics }
 
 // InboundRequest returns the inbound request associated with the given
 // context, or nil if ctx does not have an inbound request. The context passed
@@ -37,7 +35,7 @@ type inboundRequestKey struct{}
 // passed to the handler by *jrpc2.Server will support notifications if the
 // server was constructed with the AllowPush option set true.
 func PushNotify(ctx context.Context, method string, params interface{}) error {
-	return ctx.Value(serverKey{}).(*Server).Notify(ctx, method, params)
+	return ServerFromContext(ctx).Notify(ctx, method, params)
 }
 
 // PushCall posts a server call to the client. If ctx does not contain a server
@@ -48,7 +46,7 @@ func PushNotify(ctx context.Context, method string, params interface{}) error {
 // A successful callback reports a nil error and a non-nil response. Errors
 // returned by the client have concrete type *jrpc2.Error.
 func PushCall(ctx context.Context, method string, params interface{}) (*Response, error) {
-	return ctx.Value(serverKey{}).(*Server).Callback(ctx, method, params)
+	return ServerFromContext(ctx).Callback(ctx, method, params)
 }
 
 // CancelRequest requests the server associated with ctx to cancel the pending

--- a/ctx.go
+++ b/ctx.go
@@ -59,6 +59,15 @@ func CancelRequest(ctx context.Context, id string) {
 	s.cancelRequests(ctx, []json.RawMessage{json.RawMessage(id)})
 }
 
+// ServerFromContext returns the server associated with the given context.
+// This will be populated on the context passed to request handlers.
+//
+// It is safe to retain the server and invoke its methods beyond the lifetime
+// of the context from which it was extracted; however, a handler must not
+// block on the Wait or WaitStatus methods of the server, as the server will
+// deadlock waiting for the handler to return.
+func ServerFromContext(ctx context.Context) *Server { return ctx.Value(serverKey{}).(*Server) }
+
 type serverKey struct{}
 
 // ErrPushUnsupported is returned by PushNotify and PushCall if server pushes

--- a/ctx.go
+++ b/ctx.go
@@ -7,9 +7,10 @@ import (
 	"github.com/creachadair/jrpc2/metrics"
 )
 
-// ServerMetrics returns the server metrics collector associated with the given
-// context, or nil if ctx does not have a collector attached.  The context
-// passed to a handler by *jrpc2.Server will include this value.
+// ServerMetrics returns the server metrics collector. If the server does not
+// have a metrics collector, it returns nil, which is ready for use but
+// discards all posted metrics.  This function is for use by handlers, and will
+// panic for a non-handler context.
 func ServerMetrics(ctx context.Context) *metrics.M { return ServerFromContext(ctx).metrics }
 
 // InboundRequest returns the inbound request associated with the given

--- a/ctx.go
+++ b/ctx.go
@@ -29,21 +29,19 @@ func InboundRequest(ctx context.Context) *Request {
 
 type inboundRequestKey struct{}
 
-// PushNotify posts a server notification to the client. If ctx does not
-// contain a server notifier, this reports ErrPushUnsupported. The context
-// passed to the handler by *jrpc2.Server will support notifications if the
-// server was constructed with the AllowPush option set true.
+// PushNotify posts a server notification to the client. If the server does not
+// have push enabled (via the AllowPush option), it reports ErrPushUnsupported.
+// This function is for use by handlers, and will panic for a non-handler context.
 func PushNotify(ctx context.Context, method string, params interface{}) error {
 	return ServerFromContext(ctx).Notify(ctx, method, params)
 }
 
-// PushCall posts a server call to the client. If ctx does not contain a server
-// caller, this reports ErrPushUnsupported. The context passed to the handler
-// by *jrpc2.Server will support callbacks if the server was constructed with
-// the AllowPush option set true.
+// PushCall posts a server call to the client. If the server does not have push
+// enabled (via the AllowPush option), it reports ErrPushUnsupported.
+// This function is for use by handlers, and will panic for a non-handler context.
 //
 // A successful callback reports a nil error and a non-nil response. Errors
-// returned by the client have concrete type *jrpc2.Error.
+// reported by the client have concrete type *jrpc2.Error.
 func PushCall(ctx context.Context, method string, params interface{}) (*Response, error) {
 	return ServerFromContext(ctx).Callback(ctx, method, params)
 }
@@ -51,10 +49,12 @@ func PushCall(ctx context.Context, method string, params interface{}) (*Response
 // CancelRequest requests the server associated with ctx to cancel the pending
 // or in-flight request with the specified ID.  If no request exists with that
 // ID, this is a no-op without error.
+// This function is for use by handlers, and will panic for a non-handler context.
 func CancelRequest(ctx context.Context, id string) { ServerFromContext(ctx).CancelRequest(id) }
 
 // ServerFromContext returns the server associated with the given context.
 // This will be populated on the context passed to request handlers.
+// This function is for use by handlers, and will panic for a non-handler context.
 //
 // It is safe to retain the server and invoke its methods beyond the lifetime
 // of the context from which it was extracted; however, a handler must not

--- a/jrpc2_test.go
+++ b/jrpc2_test.go
@@ -1126,3 +1126,21 @@ func TestStrictFields(t *testing.T) {
 		}
 	})
 }
+
+func TestServerFromContext(t *testing.T) {
+	var got *jrpc2.Server
+	loc := server.NewLocal(handler.Map{
+		"Test": handler.New(func(ctx context.Context) error {
+			got = jrpc2.ServerFromContext(ctx)
+			return nil
+		}),
+	}, nil)
+	defer loc.Close()
+
+	if _, err := loc.Client.Call(context.Background(), "Test", nil); err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if got != loc.Server {
+		t.Errorf("ServerFromContext: got %p, want %p", got, loc.Server)
+	}
+}

--- a/jrpc2_test.go
+++ b/jrpc2_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -704,7 +705,9 @@ func TestPushNotify(t *testing.T) {
 	}
 
 	// Shut everything down to be sure the callbacks have settled.
+	// Sort the results since the order of arrival may vary.
 	loc.Close()
+	sort.Strings(notes)
 
 	want := []string{"explicit", "method"}
 	if diff := cmp.Diff(want, notes); diff != "" {

--- a/jrpc2_test.go
+++ b/jrpc2_test.go
@@ -1135,10 +1135,11 @@ func TestServerFromContext(t *testing.T) {
 			return nil
 		}),
 	}, nil)
-	defer loc.Close()
-
 	if _, err := loc.Client.Call(context.Background(), "Test", nil); err != nil {
 		t.Fatalf("Call failed: %v", err)
+	}
+	if err := loc.Close(); err != nil {
+		t.Errorf("Close failed: %v", err)
 	}
 	if got != loc.Server {
 		t.Errorf("ServerFromContext: got %p, want %p", got, loc.Server)

--- a/special.go
+++ b/special.go
@@ -22,11 +22,11 @@ func (s *Server) handleRPCCancel(ctx context.Context, req *Request) (interface{}
 	if err := req.UnmarshalParams(&ids); err != nil {
 		return nil, err
 	}
-	s.cancelRequests(ctx, ids)
+	s.cancelRequests(ids)
 	return nil, nil
 }
 
-func (s *Server) cancelRequests(ctx context.Context, ids []json.RawMessage) {
+func (s *Server) cancelRequests(ids []json.RawMessage) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, raw := range ids {
@@ -35,6 +35,12 @@ func (s *Server) cancelRequests(ctx context.Context, ids []json.RawMessage) {
 			s.log("Cancelled request %s by client order", id)
 		}
 	}
+}
+
+// CancelRequest instructs s to cancel the pending or in-flight request with
+// the specified ID. If no request exists with that ID, this is a no-op.
+func (s *Server) CancelRequest(id string) {
+	s.cancelRequests([]json.RawMessage{json.RawMessage(id)})
 }
 
 // methodFunc is a replication of handler.Func redeclared to avert a cycle.


### PR DESCRIPTION
Add a top-level `ServerFromContext` function that recovers the `*Server` value from
the context passed to a handler.

Related changes:
- Clean up some redundant flag checks in the context handlers.
- Rewrite the existing context handlers in terms of this new function.
- Add a top-level `CancelRequest` method on the `Server`.

Fixes #38.

