### PR TITLE
jhttp: Re-work the Bridge interface to require less plumbing.

### DIFF
--- a/cmd/examples/http/server.go
+++ b/cmd/examples/http/server.go
@@ -41,7 +41,7 @@ func main() {
 		Logger:  log.New(os.Stderr, "[jhttp.Bridge] ", log.LstdFlags|log.Lshortfile),
 		Metrics: metrics.New(),
 	})
-	bridge := jhttp.NewBridge(srv)
+	bridge := jhttp.NewBridge(srv, nil)
 	defer bridge.Close()
 
 	http.Handle("/rpc", bridge)

--- a/cmd/examples/http/server.go
+++ b/cmd/examples/http/server.go
@@ -22,7 +22,6 @@ import (
 	"github.com/creachadair/jrpc2/handler"
 	"github.com/creachadair/jrpc2/jhttp"
 	"github.com/creachadair/jrpc2/metrics"
-	"github.com/creachadair/jrpc2/server"
 )
 
 var port = flag.Int("port", 0, "Service port")
@@ -34,16 +33,17 @@ func main() {
 	}
 
 	// Start a local server with a single trivial method and bridge it to HTTP.
-	local := server.NewLocal(handler.Map{
+	srv := jrpc2.NewServer(handler.Map{
 		"Ping": handler.New(func(ctx context.Context, msg ...string) string {
 			return "OK: " + strings.Join(msg, ", ")
 		}),
-	}, &server.LocalOptions{
-		Server: &jrpc2.ServerOptions{
-			Logger:  log.New(os.Stderr, "[jhttp.Bridge] ", log.LstdFlags|log.Lshortfile),
-			Metrics: metrics.New(),
-		},
+	}, &jrpc2.ServerOptions{
+		Logger:  log.New(os.Stderr, "[jhttp.Bridge] ", log.LstdFlags|log.Lshortfile),
+		Metrics: metrics.New(),
 	})
-	http.Handle("/rpc", jhttp.NewBridge(local.Client))
+	bridge := jhttp.NewBridge(srv)
+	defer bridge.Close()
+
+	http.Handle("/rpc", bridge)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", *port), nil))
 }

--- a/jhttp/example_test.go
+++ b/jhttp/example_test.go
@@ -22,7 +22,7 @@ func Example() {
 		}),
 	}, nil)
 
-	b := jhttp.NewBridge(srv)
+	b := jhttp.NewBridge(srv, nil)
 	defer b.Close()
 
 	hsrv := httptest.NewServer(b)

--- a/jhttp/example_test.go
+++ b/jhttp/example_test.go
@@ -9,21 +9,20 @@ import (
 	"net/http/httptest"
 	"strings"
 
+	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/handler"
 	"github.com/creachadair/jrpc2/jhttp"
-	"github.com/creachadair/jrpc2/server"
 )
 
 func Example() {
 	// Set up a local server to demonstrate the API.
-	loc := server.NewLocal(handler.Map{
+	srv := jrpc2.NewServer(handler.Map{
 		"Test": handler.New(func(ctx context.Context, ss ...string) (string, error) {
 			return strings.Join(ss, " "), nil
 		}),
 	}, nil)
-	defer loc.Close()
 
-	b := jhttp.NewBridge(loc.Client)
+	b := jhttp.NewBridge(srv)
 	defer b.Close()
 
 	hsrv := httptest.NewServer(b)


### PR DESCRIPTION
This change is in support of #46. It is a breaking change to the jhttp.Bridge API.

The purpose of a jhttp.Bridge is to convey requests from an HTTP handler into a
JSON-RPC server. The way I had implemented it, however, required interposing a
client, which complicated the logic of forwarding.

Instead of requiring a client, the Bridge now takes an unstarted server, and
starts it up on an in-memory channel. We still have to parse the requests to
detect whether there are any calls, since HTTP requires a response regardless
of whether the JSON-RPC server replies, but we no longer need to virtualize
request IDs or re-marshal the request values.