### PR TITLE
Unify the names of the unmarshal methods for Request and Response

### DIFF
--- a/base.go
+++ b/base.go
@@ -66,7 +66,7 @@ func (r *Request) Method() string { return r.method }
 // HasParams reports whether the request has non-empty parameters.
 func (r *Request) HasParams() bool { return len(r.params) != 0 }
 
-// UnmarshalParams decodes the request parameters of r into v. If r has empty
+// UnmarshalData decodes the request parameters of r into v. If r has empty
 // parameters, it returns nil without modifying v. If r is invalid it returns
 // an InvalidParams error.
 //
@@ -78,7 +78,7 @@ func (r *Request) HasParams() bool { return len(r.params) != 0 }
 //
 // If r has parameters and v has type *json.RawMessage, unmarshaling will
 // always succeed.
-func (r *Request) UnmarshalParams(v interface{}) error {
+func (r *Request) UnmarshalData(v interface{}) error {
 	if len(r.params) == 0 {
 		return nil
 	}
@@ -150,8 +150,8 @@ func (r *Response) ID() string { return r.id }
 // Error returns a non-nil *Error if the response contains an error.
 func (r *Response) Error() *Error { return r.err }
 
-// UnmarshalResult decodes the result message into v. If the request failed,
-// UnmarshalResult returns the *Error value that would also be returned by
+// UnmarshalData decodes the result message into v. If the request failed,
+// UnmarshalData returns the *Error value that would also be returned by
 // r.Error(), and v is unmodified.
 //
 // By default, unknown object keys are ignored when unmarshaling into a v of
@@ -162,7 +162,7 @@ func (r *Response) Error() *Error { return r.err }
 //
 // If r has a result and v has type *json.RawMessage, unmarshaling will always
 // succeed.
-func (r *Response) UnmarshalResult(v interface{}) error {
+func (r *Response) UnmarshalData(v interface{}) error {
 	if r.err != nil {
 		return r.err
 	}
@@ -468,7 +468,7 @@ type strictFielder interface {
 // For example:
 //
 //       var obj RequestType
-//       err := req.UnmarshalParams(jrpc2.StrictFields(&obj))`
+//       err := req.UnmarshalData(jrpc2.StrictFields(&obj))`
 //
 func StrictFields(v interface{}) interface{} { return &strict{v: v} }
 

--- a/client.go
+++ b/client.go
@@ -306,13 +306,13 @@ func (c *Client) Call(ctx context.Context, method string, params interface{}) (*
 
 // CallResult invokes Call with the given method and params. If it succeeds,
 // the result is decoded into result. This is a convenient shorthand for Call
-// followed by UnmarshalResult. It will panic if result == nil.
+// followed by UnmarshalData. It will panic if result == nil.
 func (c *Client) CallResult(ctx context.Context, method string, params, result interface{}) error {
 	rsp, err := c.Call(ctx, method, params)
 	if err != nil {
 		return err
 	}
-	return rsp.UnmarshalResult(result)
+	return rsp.UnmarshalData(result)
 }
 
 // Batch initiates a batch of concurrent requests, and blocks until all the

--- a/cmd/examples/client/client.go
+++ b/cmd/examples/client/client.go
@@ -48,8 +48,8 @@ type binarg struct{ X, Y int }
 
 func intResult(rsp *jrpc2.Response) int {
 	var v int
-	if err := rsp.UnmarshalResult(&v); err != nil {
-		log.Fatalln("UnmarshalResult:", err)
+	if err := rsp.UnmarshalData(&v); err != nil {
+		log.Fatalln("UnmarshalData:", err)
 	}
 	return v
 }
@@ -70,7 +70,7 @@ func main() {
 	cli := jrpc2.NewClient(channel.RawJSON(conn, conn), &jrpc2.ClientOptions{
 		OnNotify: func(req *jrpc2.Request) {
 			var params json.RawMessage
-			req.UnmarshalParams(&params)
+			req.UnmarshalData(&params)
 			log.Printf("[server push] Method %q params %#q", req.Method(), string(params))
 		},
 	})

--- a/cmd/jcall/jcall.go
+++ b/cmd/jcall/jcall.go
@@ -146,7 +146,7 @@ func newClient(conn channel.Channel) *jrpc2.Client {
 	opts := &jrpc2.ClientOptions{
 		OnNotify: func(req *jrpc2.Request) {
 			var p json.RawMessage
-			req.UnmarshalParams(&p)
+			req.UnmarshalData(&p)
 			fmt.Printf(`{"method":%q,"params":%s}`+"\n", req.Method(), string(p))
 		},
 	}
@@ -180,7 +180,7 @@ func printResults(rsps []*jrpc2.Response) (time.Duration, error) {
 		}
 		pstart := time.Now()
 		var result json.RawMessage
-		if perr := rsp.UnmarshalResult(&result); perr != nil {
+		if perr := rsp.UnmarshalData(&result); perr != nil {
 			log.Printf("Decoding (%d): %v", i+1, perr)
 			set(perr)
 			continue
@@ -232,7 +232,7 @@ func issueSequential(ctx context.Context, cli *jrpc2.Client, specs []jrpc2.Spec)
 		cdur := time.Since(cstart)
 		pstart := time.Now()
 		var result json.RawMessage
-		if perr := rsp.UnmarshalResult(&result); perr != nil {
+		if perr := rsp.UnmarshalData(&result); perr != nil {
 			return dur, err
 		}
 		fmt.Println(string(result))

--- a/doc.go
+++ b/doc.go
@@ -106,11 +106,11 @@ call reflects an error in sending the request: The caller must check each
 response separately for errors from the server. Responses are returned in the
 same order as the Spec values, save that notifications are omitted.
 
-To decode the result from a successful response use its UnmarshalResult method:
+To decode the result from a successful response use its UnmarshalData method:
 
    var result int
-   if err := rsp.UnmarshalResult(&result); err != nil {
-      log.Fatalln("UnmarshalResult:", err)
+   if err := rsp.UnmarshalData(&result); err != nil {
+      log.Fatalln("UnmarshalData:", err)
    }
 
 To close a client and discard all its pending work, call cli.Close().

--- a/examples_test.go
+++ b/examples_test.go
@@ -69,7 +69,7 @@ func ExampleClient_Call() {
 		log.Fatalf("Call: %v", err)
 	}
 	var msg string
-	if err := rsp.UnmarshalResult(&msg); err != nil {
+	if err := rsp.UnmarshalData(&msg); err != nil {
 		log.Fatalf("Decoding result: %v", err)
 	}
 	fmt.Println(msg)
@@ -105,7 +105,7 @@ func ExampleClient_Batch() {
 	fmt.Printf("len(rsps) = %d\n", len(rsps))
 	for i, rsp := range rsps {
 		var msg string
-		if err := rsp.UnmarshalResult(&msg); err != nil {
+		if err := rsp.UnmarshalData(&msg); err != nil {
 			log.Fatalf("Invalid result: %v", err)
 		}
 		fmt.Printf("Response #%d: %s\n", i+1, msg)
@@ -116,7 +116,7 @@ func ExampleClient_Batch() {
 	// Response #1: Hello, world!
 }
 
-func ExampleRequest_UnmarshalParams() {
+func ExampleRequest_UnmarshalData() {
 	const msg = `{"jsonrpc":"2.0", "id":101, "method":"M", "params":{"a":1, "b":2, "c":3}}`
 
 	reqs, err := jrpc2.ParseRequests([]byte(msg))
@@ -130,20 +130,20 @@ func ExampleRequest_UnmarshalParams() {
 	}
 
 	// By default, unmarshaling ignores unknown fields (here, "c").
-	if err := reqs[0].UnmarshalParams(&t); err != nil {
-		log.Fatalf("UnmarshalParams: %v", err)
+	if err := reqs[0].UnmarshalData(&t); err != nil {
+		log.Fatalf("UnmarshalData: %v", err)
 	}
 
 	// Solution 1: Use the jrpc2.StrictFields helper.
-	err = reqs[0].UnmarshalParams(jrpc2.StrictFields(&t))
+	err = reqs[0].UnmarshalData(jrpc2.StrictFields(&t))
 	if code.FromError(err) != code.InvalidParams {
-		log.Fatalf("UnmarshalParams strict: %v", err)
+		log.Fatalf("UnmarshalData strict: %v", err)
 	}
 	fmt.Printf("t.A=%d, t.B=%d\n", t.A, t.B)
 
 	// Solution 2: Unmarshal as json.RawMessage and decode separately.
 	var tmp json.RawMessage
-	reqs[0].UnmarshalParams(&tmp) // cannot fail
+	reqs[0].UnmarshalData(&tmp) // cannot fail
 	if err := json.Unmarshal(tmp, &u); err != nil {
 		log.Fatalf("Unmarshal: %v", err)
 	}
@@ -154,7 +154,7 @@ func ExampleRequest_UnmarshalParams() {
 	// u.A=1, u.B=2
 }
 
-func ExampleResponse_UnmarshalResult() {
+func ExampleResponse_UnmarshalData() {
 	// var cli = jrpc2.NewClient(cch, nil)
 	rsp, err := cli.Call(ctx, "Echo", []string{"alpha", "oscar", "kilo"})
 	if err != nil {
@@ -163,7 +163,7 @@ func ExampleResponse_UnmarshalResult() {
 	var r1, r3 string
 
 	// Note the nil, which tells the decoder to skip that argument.
-	if err := rsp.UnmarshalResult(&handler.Args{&r1, nil, &r3}); err != nil {
+	if err := rsp.UnmarshalData(&handler.Args{&r1, nil, &r3}); err != nil {
 		log.Fatalf("Decoding result: %v", err)
 	}
 	fmt.Println(r1, r3)

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -158,7 +158,7 @@ func (fi *FuncInfo) Wrap() Func {
 		// Case 3a: The function wants a pointer to its argument value.
 		newInput = func(ctx reflect.Value, req *jrpc2.Request) ([]reflect.Value, error) {
 			in := reflect.New(fi.Argument.Elem())
-			if err := req.UnmarshalParams(in.Interface()); err != nil {
+			if err := req.UnmarshalData(in.Interface()); err != nil {
 				return nil, jrpc2.Errorf(code.InvalidParams, "invalid parameters: %v", err)
 			}
 			return []reflect.Value{ctx, in}, nil
@@ -167,7 +167,7 @@ func (fi *FuncInfo) Wrap() Func {
 		// Case 3b: The function wants a bare argument value.
 		newInput = func(ctx reflect.Value, req *jrpc2.Request) ([]reflect.Value, error) {
 			in := reflect.New(fi.Argument) // we still need a pointer to unmarshal
-			if err := req.UnmarshalParams(in.Interface()); err != nil {
+			if err := req.UnmarshalData(in.Interface()); err != nil {
 				return nil, jrpc2.Errorf(code.InvalidParams, "invalid parameters: %v", err)
 			}
 			// Indirect the pointer back off for the callee.
@@ -302,7 +302,7 @@ func Check(fn interface{}) (*FuncInfo, error) {
 //       var x, y int
 //       var s string
 //
-//       if err := req.UnmarshalParams(&handler.Args{&x, &y, &s}); err != nil {
+//       if err := req.UnmarshalData(&handler.Args{&x, &y, &s}); err != nil {
 //          return nil, err
 //       }
 //       // do useful work with x, y, and s

--- a/internal_test.go
+++ b/internal_test.go
@@ -80,7 +80,7 @@ func errEQ(x, y error) bool {
 	return code.FromError(x) == code.FromError(y) && x.Error() == y.Error()
 }
 
-func TestUnmarshalParams(t *testing.T) {
+func TestUnmarshalData(t *testing.T) {
 	type xy struct {
 		X int  `json:"x"`
 		Y bool `json:"y"`
@@ -120,9 +120,9 @@ func TestUnmarshalParams(t *testing.T) {
 		// Allocate a zero of the expected type to unmarshal into.
 		target := reflect.New(reflect.TypeOf(test.want)).Interface()
 		{
-			err := req[0].UnmarshalParams(target)
+			err := req[0].UnmarshalData(target)
 			if got := code.FromError(err); got != test.code {
-				t.Errorf("UnmarshalParams error: got code %d, want %d [%v]", got, test.code, err)
+				t.Errorf("UnmarshalData error: got code %d, want %d [%v]", got, test.code, err)
 			}
 			if err != nil {
 				continue

--- a/jrpc2_test.go
+++ b/jrpc2_test.go
@@ -50,7 +50,7 @@ func (dummy) Add(_ context.Context, req *jrpc2.Request) (interface{}, error) {
 		return nil, errors.New("ignoring notification")
 	}
 	var vals []int
-	if err := req.UnmarshalParams(&vals); err != nil {
+	if err := req.UnmarshalData(&vals); err != nil {
 		return nil, err
 	}
 	var sum int
@@ -150,7 +150,7 @@ func TestCall(t *testing.T) {
 			continue
 		}
 		var got int
-		if err := rsp.UnmarshalResult(&got); err != nil {
+		if err := rsp.UnmarshalData(&got); err != nil {
 			t.Errorf("Unmarshaling result: %v", err)
 			continue
 		}
@@ -226,7 +226,7 @@ func TestBatch(t *testing.T) {
 			continue
 		}
 		var got int
-		if err := rsp.UnmarshalResult(&got); err != nil {
+		if err := rsp.UnmarshalData(&got); err != nil {
 			t.Errorf("Umarshaling result %d: %v", i+1, err)
 			continue
 		}
@@ -243,7 +243,7 @@ func TestNotificationOrder(t *testing.T) {
 	loc := server.NewLocal(handler.Map{
 		"Test": handler.New(func(_ context.Context, req *jrpc2.Request) error {
 			var seq int32
-			if err := req.UnmarshalParams(&handler.Args{&seq}); err != nil {
+			if err := req.UnmarshalData(&handler.Args{&seq}); err != nil {
 				t.Errorf("Invalid test parameters: %v", err)
 				return err
 			}
@@ -301,7 +301,7 @@ func TestErrorOnly(t *testing.T) {
 		// Per https://www.jsonrpc.org/specification#response_object, a "result"
 		// field is required on success, so verify that it is set null.
 		var got json.RawMessage
-		if err := rsp.UnmarshalResult(&got); err != nil {
+		if err := rsp.UnmarshalData(&got); err != nil {
 			t.Fatalf("Failed to unmarshal result data: %v", err)
 		} else if r := string(got); r != "null" {
 			t.Errorf("ErrorOnly response: got %q, want null", r)
@@ -389,7 +389,7 @@ func TestHandlerCancel(t *testing.T) {
 		}),
 		"Test": handler.New(func(ctx context.Context, req *jrpc2.Request) error {
 			var id string
-			if err := req.UnmarshalParams(&handler.Args{&id}); err != nil {
+			if err := req.UnmarshalData(&handler.Args{&id}); err != nil {
 				return err
 			}
 			t.Logf("Test handler: cancelling %q...", id)
@@ -1106,11 +1106,11 @@ func TestStrictFields(t *testing.T) {
 		"Test": handler.New(func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
 			var ps, qs params
 
-			if err := req.UnmarshalParams(jrpc2.StrictFields(&ps)); err == nil {
+			if err := req.UnmarshalData(jrpc2.StrictFields(&ps)); err == nil {
 				t.Errorf("Unmarshal strict: got %+v, want error", ps)
 			}
 
-			if err := req.UnmarshalParams(&qs); err != nil {
+			if err := req.UnmarshalData(&qs); err != nil {
 				t.Errorf("Unmarshal non-strict (default): unexpected error: %v", err)
 			} else {
 				t.Logf("Parameters OK: %+v", qs)
@@ -1137,18 +1137,18 @@ func TestStrictFields(t *testing.T) {
 
 	t.Run("NonStrictResult", func(t *testing.T) {
 		var res result
-		if err := rsp.UnmarshalResult(&res); err != nil {
-			t.Errorf("UnmarshalResult: %v", err)
+		if err := rsp.UnmarshalData(&res); err != nil {
+			t.Errorf("UnmarshalData: %v", err)
 		}
 		t.Logf("Result: %+v", res)
 	})
 
 	t.Run("StrictResult", func(t *testing.T) {
 		var res result
-		if err := rsp.UnmarshalResult(jrpc2.StrictFields(&res)); err == nil {
-			t.Errorf("UnmarshalResult: got %+v, want error", res)
+		if err := rsp.UnmarshalData(jrpc2.StrictFields(&res)); err == nil {
+			t.Errorf("UnmarshalData: got %+v, want error", res)
 		} else {
-			t.Logf("UnmarshalResult: got expected error: %v", err)
+			t.Logf("UnmarshalData: got expected error: %v", err)
 		}
 	})
 }

--- a/regression_test.go
+++ b/regression_test.go
@@ -22,7 +22,7 @@ func TestLockRaceRegression(t *testing.T) {
 			defer close(hdone) // signal we passed the deadlock point
 
 			var id string
-			if err := req.UnmarshalParams(&handler.Args{&id}); err != nil {
+			if err := req.UnmarshalData(&handler.Args{&id}); err != nil {
 				return err
 			}
 			jrpc2.ServerFromContext(ctx).CancelRequest(id)


### PR DESCRIPTION
Requested in https://github.com/creachadair/jrpc2/issues/46#issuecomment-919436490

I'm not sure how I feel about this change. It seems harmless enough.