### PR TITLE
server: Handle context termination for pending callbacks.

### DIFF
--- a/server.go
+++ b/server.go
@@ -396,8 +396,8 @@ func (s *Server) Notify(ctx context.Context, method string, params interface{}) 
 //
 // This is a non-standard extension of JSON-RPC, and may not be supported by
 // all clients. If you are not sure whether the client supports push calls, you
-// should set a deadeline on ctx, otherwise the callback may block forever for
-// a client response that will never arrive.
+// should set a deadline on ctx, otherwise the callback may block forever for a
+// client response that will never arrive.
 //
 // Unless s was constructed with the AllowPush option set true, this method
 // will always report an error (ErrPushUnsupported) without sending


### PR DESCRIPTION
Prior to this change, calls pushed from the server to the client would ignore
the context passed to the Callback method. This meant that if the client did
not reply (for example, the client has no support for push calls), the callback
would block forever.

This change makes pending callbacks on the server respect the context that was
passed to the Callback method: When it ends, if the call has not yet received a
response, it is delivered an error from the context and resolved.

Update the documentation on Callback to recommend setting a timeout or deadline
on the context, in cases where the client might not reply.