### PR TITLE
Revert the interface changes to jhttp.Bridge from #52.

### DIFF
--- a/base.go
+++ b/base.go
@@ -147,6 +147,9 @@ type Response struct {
 // ID returns the request identifier for r.
 func (r *Response) ID() string { return r.id }
 
+// SetID sets the ID of r to s, for use in proxies.
+func (r *Response) SetID(s string) { r.id = s }
+
 // Error returns a non-nil *Error if the response contains an error.
 func (r *Response) Error() *Error { return r.err }
 

--- a/jhttp/example_test.go
+++ b/jhttp/example_test.go
@@ -9,20 +9,17 @@ import (
 	"net/http/httptest"
 	"strings"
 
-	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/handler"
 	"github.com/creachadair/jrpc2/jhttp"
 )
 
 func Example() {
-	// Set up a local server to demonstrate the API.
-	srv := jrpc2.NewServer(handler.Map{
+	// Set up a bridge to demonstrate the API.
+	b := jhttp.NewBridge(handler.Map{
 		"Test": handler.New(func(ctx context.Context, ss ...string) (string, error) {
 			return strings.Join(ss, " "), nil
 		}),
 	}, nil)
-
-	b := jhttp.NewBridge(srv, nil)
 	defer b.Close()
 
 	hsrv := httptest.NewServer(b)


### PR DESCRIPTION
This change mostly reverts the changes to `jhttp.Bridge` from #52, but respecting some of the other changes in the package since that was merged. This fixes the problems with ID collisions, by restoring the virtualization.

The resulting interface is different from both the original interface (where the bridge accepted a client) and the "simplified" interface (where the bridge accepts a server). Now the bridge behaves more like the local server from the `server` package, except that it retains awareness of the HTTP infrastructure.

Fixes #57.