### PR TITLE
Remove the client and server "AllowV1" settings.

### DIFF
--- a/client.go
+++ b/client.go
@@ -27,8 +27,6 @@ type Client struct {
 	cbctx    context.Context // terminates when the client is closed
 	cbcancel func()          // cancels cbctx
 
-	allow1 bool // tolerate v1 replies with no version marker
-
 	mu      sync.Mutex           // protects the fields below
 	ch      channel.Channel      // channel to the server
 	err     error                // error from a previous operation
@@ -40,13 +38,12 @@ type Client struct {
 func NewClient(ch channel.Channel, opts *ClientOptions) *Client {
 	cbctx, cbcancel := context.WithCancel(context.Background())
 	c := &Client{
-		done:   new(sync.WaitGroup),
-		log:    opts.logFunc(),
-		allow1: opts.allowV1(),
-		enctx:  opts.encodeContext(),
-		snote:  opts.handleNotification(),
-		scall:  opts.handleCallback(),
-		chook:  opts.handleCancel(),
+		done:  new(sync.WaitGroup),
+		log:   opts.logFunc(),
+		enctx: opts.encodeContext(),
+		snote: opts.handleNotification(),
+		scall: opts.handleCallback(),
+		chook: opts.handleCancel(),
 
 		cbctx:    cbctx,
 		cbcancel: cbcancel,
@@ -423,12 +420,7 @@ func (c *Client) stop(err error) {
 	c.ch = nil
 }
 
-func (c *Client) versionOK(v string) bool {
-	if v == "" {
-		return c.allow1
-	}
-	return v == Version
-}
+func (c *Client) versionOK(v string) bool { return v == Version }
 
 // marshalParams validates and marshals params to JSON for a request.  The
 // value of params must be either nil or encodable as a JSON object or array.

--- a/jrpc2_test.go
+++ b/jrpc2_test.go
@@ -134,10 +134,7 @@ func TestClient_Call(t *testing.T) {
 	loc := server.NewLocal(handler.ServiceMap{
 		"Test": testService,
 	}, &server.LocalOptions{
-		Server: &jrpc2.ServerOptions{
-			AllowV1:     true,
-			Concurrency: 16,
-		},
+		Server: &jrpc2.ServerOptions{Concurrency: 16},
 	})
 	defer loc.Close()
 	c := loc.Client
@@ -191,10 +188,7 @@ func TestClient_Batch(t *testing.T) {
 	loc := server.NewLocal(handler.ServiceMap{
 		"Test": testService,
 	}, &server.LocalOptions{
-		Server: &jrpc2.ServerOptions{
-			AllowV1:     true,
-			Concurrency: 16,
-		},
+		Server: &jrpc2.ServerOptions{Concurrency: 16},
 	})
 	defer loc.Close()
 	c := loc.Client

--- a/opts.go
+++ b/opts.go
@@ -23,10 +23,6 @@ type ServerOptions struct {
 	// received and each response or error returned.
 	RPCLog RPCLogger
 
-	// Instructs the server to tolerate requests that do not include the
-	// required "jsonrpc" version marker.
-	AllowV1 bool
-
 	// Instructs the server to allow server callbacks and notifications, a
 	// non-standard extension to the JSON-RPC protocol. If AllowPush is false,
 	// the Notify and Callback methods of the server report errors if called.
@@ -79,7 +75,6 @@ func (s *ServerOptions) logFunc() func(string, ...interface{}) {
 	return s.Logger.Printf
 }
 
-func (s *ServerOptions) allowV1() bool      { return s != nil && s.AllowV1 }
 func (s *ServerOptions) allowPush() bool    { return s != nil && s.AllowPush }
 func (s *ServerOptions) allowBuiltin() bool { return s == nil || !s.DisableBuiltin }
 
@@ -144,10 +139,6 @@ type ClientOptions struct {
 	// If not nil, send debug text logs here.
 	Logger Logger
 
-	// Instructs the client to tolerate responses that do not include the
-	// required "jsonrpc" version marker.
-	AllowV1 bool
-
 	// If set, this function is called with the context, method name, and
 	// encoded request parameters before the request is sent to the server.
 	// Its return value replaces the request parameters. This allows the client
@@ -190,8 +181,6 @@ func (c *ClientOptions) logFunc() func(string, ...interface{}) {
 	}
 	return c.Logger.Printf
 }
-
-func (c *ClientOptions) allowV1() bool { return c != nil && c.AllowV1 }
 
 type encoder = func(context.Context, string, json.RawMessage) (json.RawMessage, error)
 

--- a/server.go
+++ b/server.go
@@ -26,7 +26,6 @@ type Server struct {
 	sem *semaphore.Weighted // bounds concurrent execution (default 1)
 
 	// Configurable settings
-	allow1  bool                         // allow v1 requests with no version marker
 	allowP  bool                         // allow server notifications to the client
 	log     func(string, ...interface{}) // write debug logs here
 	rpcLog  RPCLogger                    // log RPC requests and responses here
@@ -71,7 +70,6 @@ func NewServer(mux Assigner, opts *ServerOptions) *Server {
 	s := &Server{
 		mux:     mux,
 		sem:     semaphore.NewWeighted(opts.concurrency()),
-		allow1:  opts.allowV1(),
 		allowP:  opts.allowPush(),
 		log:     opts.logFunc(),
 		rpcLog:  opts.rpcLog(),
@@ -693,12 +691,7 @@ func (s *Server) cancel(id string) bool {
 	return ok
 }
 
-func (s *Server) versionOK(v string) bool {
-	if v == "" {
-		return s.allow1 // an empty version is OK if the server allows it
-	}
-	return v == Version // ... otherwise it must match the spec
-}
+func (s *Server) versionOK(v string) bool { return v == Version }
 
 // A task represents a pending method invocation received by the server.
 type task struct {


### PR DESCRIPTION
The intent of these options was to tolerate calls to/from JSON-RPC 1.0
implementations. That alone isn't enough for interoperability, however.

For example:

- Server replies still contain the v2 version marker, which (some) v1 clients
  do not accept.

- The v2 Error object has a stricter structure than v1, and the client only
  accepts v2.

Since this library implements v2 specifically, I do not think it's worthwhile
to add extra plumbing for those cases (e.g., tracking v1 shape through the
handler, tolerating arbitrary Error geometry). On that basis, the tolerance
settings are not carrying their weight.

For context see #44.

Updates #46