### PR TITLE
handler: support array arguments in positional wrappers

### DIFF
--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -192,10 +192,10 @@ func TestPositional_decode(t *testing.T) {
 		{`{"jsonrpc":"2.0","id":7,"method":"add"}`, 0, false},
 
 		{`{"jsonrpc":"2.0","id":10,"method":"add","params":["wrong", "type"]}`, 0, true},
-		{`{"jsonrpc":"2.0","id":11,"method":"add","params":["wrong", "type"]}`, 0, true},
-		{`{"jsonrpc":"2.0","id":12,"method":"add","params":{"unknown":"field"}}`, 0, true},
-		{`{"jsonrpc":"2.0","id":13,"method":"add","params":[1]}`, 0, true},
-		{`{"jsonrpc":"2.0","id":14,"method":"add","params":[1,2,3]}`, 0, true},
+		{`{"jsonrpc":"2.0","id":12,"method":"add","params":[15, "wrong-type"]}`, 0, true},
+		{`{"jsonrpc":"2.0","id":13,"method":"add","params":{"unknown":"field"}}`, 0, true},
+		{`{"jsonrpc":"2.0","id":14,"method":"add","params":[1]}`, 0, true},     // too few
+		{`{"jsonrpc":"2.0","id":15,"method":"add","params":[1,2,3]}`, 0, true}, // too many
 	}
 	for _, test := range tests {
 		req := mustParseRequest(t, test.input)

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -184,14 +184,18 @@ func TestPositional_decode(t *testing.T) {
 		bad   bool
 	}{
 		{`{"jsonrpc":"2.0","id":1,"method":"add","params":{"first":5,"second":3}}`, 8, false},
-		{`{"jsonrpc":"2.0","id":2,"method":"add","params":{"first":5}}`, 5, false},
-		{`{"jsonrpc":"2.0","id":3,"method":"add","params":{"second":3}}`, 3, false},
-		{`{"jsonrpc":"2.0","id":4,"method":"add","params":{}}`, 0, false},
-		{`{"jsonrpc":"2.0","id":5,"method":"add","params":null}`, 0, false},
-		{`{"jsonrpc":"2.0","id":6,"method":"add"}`, 0, false},
+		{`{"jsonrpc":"2.0","id":2,"method":"add","params":[5,3]}`, 8, false},
+		{`{"jsonrpc":"2.0","id":3,"method":"add","params":{"first":5}}`, 5, false},
+		{`{"jsonrpc":"2.0","id":4,"method":"add","params":{"second":3}}`, 3, false},
+		{`{"jsonrpc":"2.0","id":5,"method":"add","params":{}}`, 0, false},
+		{`{"jsonrpc":"2.0","id":6,"method":"add","params":null}`, 0, false},
+		{`{"jsonrpc":"2.0","id":7,"method":"add"}`, 0, false},
 
-		{`{"jsonrpc":"2.0","id":6,"method":"add","params":["wrong", "type"]}`, 0, true},
-		{`{"jsonrpc":"2.0","id":6,"method":"add","params":{"unknown":"field"}}`, 0, true},
+		{`{"jsonrpc":"2.0","id":10,"method":"add","params":["wrong", "type"]}`, 0, true},
+		{`{"jsonrpc":"2.0","id":11,"method":"add","params":["wrong", "type"]}`, 0, true},
+		{`{"jsonrpc":"2.0","id":12,"method":"add","params":{"unknown":"field"}}`, 0, true},
+		{`{"jsonrpc":"2.0","id":13,"method":"add","params":[1]}`, 0, true},
+		{`{"jsonrpc":"2.0","id":14,"method":"add","params":[1,2,3]}`, 0, true},
 	}
 	for _, test := range tests {
 		req := mustParseRequest(t, test.input)

--- a/handler/positional.go
+++ b/handler/positional.go
@@ -56,6 +56,13 @@ func NewPos(fn interface{}, names ...string) Func {
 // field keys generate an error. The field names are not required to match the
 // parameter names declared by the function; it is the names assigned here that
 // determine which object keys are accepted.
+//
+// The wrapped function will also accept a JSON array with with (exactly) the
+// same number of elements as the positional parameters:
+//
+//   [17, 23]
+//
+// Unlike the object format, no arguments can be omitted in this format.
 func Positional(fn interface{}, names ...string) (*FuncInfo, error) {
 	if fn == nil {
 		return nil, errors.New("nil function")
@@ -85,6 +92,7 @@ func Positional(fn interface{}, names ...string) (*FuncInfo, error) {
 	fi, err := Check(makeCaller(ft, fv, atype))
 	if err == nil {
 		fi.strictFields = true
+		fi.posNames = names
 	}
 	return fi, err
 }

--- a/json_test.go
+++ b/json_test.go
@@ -1,6 +1,3 @@
-//go:build oldbench
-// +build oldbench
-
 package jrpc2
 
 import (


### PR DESCRIPTION
Extend the generated wrapper for a positional function to accept parameters
encoded as a JSON array of the correct length. When decoding the params, if
names are provided and the value is an array of the correct length, rewrite the
array into an equivalent object with the names mapped.

This works because the positional names preserve the original order, and ensure
that we do not introduce any unknown fields.