### PR TITLE
Fix implementation of StrictFields.

### DIFF
--- a/base.go
+++ b/base.go
@@ -100,7 +100,10 @@ func (r *Request) UnmarshalParams(v interface{}) error {
 		}
 		return nil
 	}
-	return json.Unmarshal(r.params, v)
+	if err := json.Unmarshal(r.params, v); err != nil {
+		return Errorf(code.InvalidParams, "invalid parameters: %v", err.Error())
+	}
+	return nil
 }
 
 // ParamString returns the encoded request parameters of r as a string.

--- a/jrpc2_test.go
+++ b/jrpc2_test.go
@@ -1246,9 +1246,6 @@ func TestRequest_strictFields(t *testing.T) {
 		B int    `json:"bravo"`
 		other
 	}
-	type result struct {
-		X string `json:"xray"`
-	}
 	loc := server.NewLocal(handler.Map{
 		"Strict": handler.New(func(ctx context.Context, req *jrpc2.Request) (string, error) {
 			var ps params
@@ -1275,6 +1272,7 @@ func TestRequest_strictFields(t *testing.T) {
 		want   string
 	}{
 		{"Strict", handler.Obj{"alpha": "aiuto"}, code.NoError, "aiuto"},
+		{"Strict", handler.Obj{"alpha": "selva me", "charlie": true}, code.NoError, "selva me"},
 		{"Strict", handler.Obj{"alpha": "OK", "nonesuch": true}, code.InvalidParams, ""},
 		{"Normal", handler.Obj{"alpha": "OK", "nonesuch": true}, code.NoError, "OK"},
 	}

--- a/json.go
+++ b/json.go
@@ -276,8 +276,8 @@ type strictFielder interface {
 	DisallowUnknownFields()
 }
 
-// StrictFields wraps a value v to implement the DisallowUnknownFields method,
-// requiring unknown fields to be rejected when unmarshaling from JSON.
+// StrictFields wraps a value v to require unknown fields to be rejected when
+// unmarshaling from JSON.
 //
 // For example:
 //
@@ -288,4 +288,8 @@ func StrictFields(v interface{}) interface{} { return &strict{v: v} }
 
 type strict struct{ v interface{} }
 
-func (strict) DisallowUnknownFields() {}
+func (s *strict) UnmarshalJSON(data []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	return dec.Decode(s.v)
+}


### PR DESCRIPTION
The previous implementation did not work correctly. Instead of just adding the
strictFielder method, actually implement json.Unmarshaler.

Update the test cases to correctly exercise the intended behaviour.
