### PR TITLE
Front-load handling of callback responses from the client.

### DIFF
--- a/regression_test.go
+++ b/regression_test.go
@@ -206,14 +206,12 @@ func TestServer_NotificationCallbackDeadlock(t *testing.T) {
 			if _, err := jrpc2.ServerFromContext(ctx).Callback(ctx, "succeed", nil); err != nil {
 				t.Errorf("Callback failed: %v", err)
 			}
-			t.Log("Notification handler complete")
 			return nil
 		}),
 	}, &server.LocalOptions{
 		Server: &jrpc2.ServerOptions{AllowPush: true},
 		Client: &jrpc2.ClientOptions{
 			OnCallback: func(ctx context.Context, req *jrpc2.Request) (interface{}, error) {
-				t.Logf("OnCallback invoked for method %q", req.Method())
 				switch req.Method() {
 				case "succeed":
 					return true, nil

--- a/regression_test.go
+++ b/regression_test.go
@@ -195,7 +195,7 @@ func TestCheckBatchDuplicateID(t *testing.T) {
 }
 
 // Verify that callbacks from notification handlers cannot deadlock on delivery
-// of their own replies. Fixes #78, test case courtesy of @radeksimko.
+// of their own replies. Reported in #78, test case courtesy of @radeksimko.
 func TestServer_NotificationCallbackDeadlock(t *testing.T) {
 	defer leaktest.Check(t)()
 

--- a/server.go
+++ b/server.go
@@ -281,8 +281,7 @@ func (s *Server) checkAndAssign(next jmessages) tasks {
 	var ids []string
 	dup := make(map[string]*task) // :: id ⇒ first task in batch with id
 
-	// Phase 1: Filter out responses from push calls and check for duplicate
-	// request IDs.
+	// Phase 1: Check for errors and duplicate request IDs.
 	for _, req := range next {
 		if req.err != nil {
 			// keep the existing error

--- a/server.go
+++ b/server.go
@@ -660,7 +660,7 @@ func (s *Server) read(ch receiver) {
 // replies to pending callbacks as required. The remainder is returned.
 // The caller must hold s.mu, and must re-check that the result is not empty.
 func (s *Server) filterBatch(next jmessages) jmessages {
-	var keep jmessages
+	keep := make(jmessages, 0, len(next))
 	for _, req := range next {
 		if req.isRequestOrNotification() {
 			keep = append(keep, req)

--- a/server.go
+++ b/server.go
@@ -284,19 +284,19 @@ func (s *Server) checkAndAssign(next jmessages) tasks {
 	// Phase 1: Filter out responses from push calls and check for duplicate
 	// request IDs.
 	for _, req := range next {
-		fid := fixID(req.ID)
-		id := string(fid)
 		if req.err != nil {
 			// keep the existing error
 		} else if !s.versionOK(req.V) {
 			req.err = ErrInvalidVersion
 		}
 
+		fid := fixID(req.ID)
 		t := &task{
 			hreq:  &Request{id: fid, method: req.M, params: req.P},
 			batch: req.batch,
 			err:   req.err,
 		}
+		id := string(fid)
 		if old := dup[id]; old != nil {
 			// A previous task already used this ID, fail both.
 			old.err = errDuplicateID.WithData(id)


### PR DESCRIPTION
Previously, a notification handler that issues a call back to the client could
block delivery of the reply for its own callback: The barrier we use to
preserve issue order means another batch cannot be issued to the dispatcher
until all previously-issued notifications have completed.

To prevent the handler from deadlocking itself in this case, filter out
response messages from the client when the input is received, rather than
enqueuing them with the handlers. This basically just moves the existing logic
earlier in the transaction, but it means replies can be delivered even if the
barrier is active.

Add regression test for deadlock bug.

Fixes #78.