### PR TITLE
Rework the jrpc2.ParseRequests function.

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"strconv"
 	"sync"
@@ -150,22 +149,18 @@ func (c *Client) deliver(rsp *jmessage) {
 	}
 
 	id := string(fixID(rsp.ID))
-	if p := c.pending[id]; p == nil {
+	p := c.pending[id]
+	if p == nil {
 		c.log("Discarding response for unknown ID %q", id)
-	} else if !isValidVersion(rsp.V) {
-		delete(c.pending, id)
-		p.ch <- &jmessage{
-			ID: rsp.ID,
-			E: &Error{
-				Code:    code.InvalidRequest,
-				Message: fmt.Sprintf("incorrect version marker %q", rsp.V),
-			},
-		}
+		return
+	}
+	// Remove the pending request from the set and deliver its response.
+	// Determining whether it's an error is the caller's responsibility.
+	delete(c.pending, id)
+	if rsp.err != nil {
+		p.ch <- &jmessage{ID: rsp.ID, E: rsp.err}
 		c.log("Invalid response for ID %q", id)
 	} else {
-		// Remove the pending request from the set and deliver its response.
-		// Determining whether it's an error is the caller's responsibility.
-		delete(c.pending, id)
 		p.ch <- rsp
 		c.log("Completed request for ID %q", id)
 	}

--- a/client.go
+++ b/client.go
@@ -152,7 +152,7 @@ func (c *Client) deliver(rsp *jmessage) {
 	id := string(fixID(rsp.ID))
 	if p := c.pending[id]; p == nil {
 		c.log("Discarding response for unknown ID %q", id)
-	} else if !c.versionOK(rsp.V) {
+	} else if !isValidVersion(rsp.V) {
 		delete(c.pending, id)
 		p.ch <- &jmessage{
 			ID: rsp.ID,
@@ -421,8 +421,6 @@ func (c *Client) stop(err error) {
 	c.err = err
 	c.ch = nil
 }
-
-func (c *Client) versionOK(v string) bool { return v == Version }
 
 // marshalParams validates and marshals params to JSON for a request.  The
 // value of params must be either nil or encodable as a JSON object or array.

--- a/error.go
+++ b/error.go
@@ -61,6 +61,9 @@ var errEmptyBatch = &Error{Code: code.InvalidRequest, Message: "empty request ba
 // errInvalidParams is the error reported for invalid request parameters.
 var errInvalidParams = &Error{Code: code.InvalidParams, Message: code.InvalidParams.String()}
 
+// errTaskNotExecuted is the internal sentinel error for an unassigned task.
+var errTaskNotExecuted = new(Error)
+
 // ErrConnClosed is returned by a server's push-to-client methods if they are
 // called after the client connection is closed.
 var ErrConnClosed = errors.New("client connection is closed")

--- a/handler/example_test.go
+++ b/handler/example_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/handler"
+	"github.com/creachadair/jrpc2/internal/testutil"
 )
 
 func ExampleCheck() {
@@ -111,11 +112,9 @@ func ExamplePositional_array() {
 }
 
 func mustParseReq(s string) *jrpc2.Request {
-	reqs, err := jrpc2.ParseRequests([]byte(s))
+	req, err := testutil.ParseRequest(s)
 	if err != nil {
-		log.Fatalf("ParseRequests: %v", err)
-	} else if len(reqs) == 0 {
-		log.Fatal("ParseRequests: empty result")
+		log.Fatalf("ParseRequest: %v", err)
 	}
-	return reqs[0]
+	return req
 }

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/creachadair/jrpc2"
 	"github.com/creachadair/jrpc2/code"
 	"github.com/creachadair/jrpc2/handler"
+	"github.com/creachadair/jrpc2/internal/testutil"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -105,7 +106,7 @@ func TestFuncInfo_wrapDecode(t *testing.T) {
 	}
 	ctx := context.Background()
 	for _, test := range tests {
-		req := mustParseRequest(t,
+		req := testutil.MustParseRequest(t,
 			fmt.Sprintf(`{"jsonrpc":"2.0","id":1,"method":"x","params":%s}`, test.p))
 		got, err := test.fn(ctx, req)
 		if err != nil {
@@ -165,7 +166,7 @@ func TestNewStrict(t *testing.T) {
 	}
 	fn := handler.NewStrict(func(ctx context.Context, arg *arg) error { return nil })
 
-	req := mustParseRequest(t, `{
+	req := testutil.MustParseRequest(t, `{
    "jsonrpc": "2.0",
    "id":      100,
    "method":  "f",
@@ -199,7 +200,7 @@ func TestNew_pointerRegression(t *testing.T) {
 		t.Logf("Got argument struct: %+v", got)
 		return nil
 	})
-	req := mustParseRequest(t, `{
+	req := testutil.MustParseRequest(t, `{
    "jsonrpc": "2.0",
    "id":      "foo",
    "method":  "bar",
@@ -245,7 +246,7 @@ func TestPositional_decode(t *testing.T) {
 		{`{"jsonrpc":"2.0","id":15,"method":"add","params":[1,2,3]}`, 0, true}, // too many
 	}
 	for _, test := range tests {
-		req := mustParseRequest(t, test.input)
+		req := testutil.MustParseRequest(t, test.input)
 		got, err := call(context.Background(), req)
 		if !test.bad {
 			if err != nil {
@@ -436,17 +437,6 @@ func TestObjUnmarshal(t *testing.T) {
 			t.Errorf("Wrong values: (-want, +got)\n%s", diff)
 		}
 	}
-}
-
-func mustParseRequest(t *testing.T, text string) *jrpc2.Request {
-	t.Helper()
-	req, err := jrpc2.ParseRequests([]byte(text))
-	if err != nil {
-		t.Fatalf("ParseRequests: %v", err)
-	} else if len(req) != 1 {
-		t.Fatalf("Wrong number of requests: got %d, want 1", len(req))
-	}
-	return req[0]
 }
 
 // stringByte is a byte with a custom JSON encoding. It expects a string of

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2022 Michael J. Fromberger. All Rights Reserved.
+
 // Package testutil defines internal support code for writing tests.
 package testutil
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,52 @@
+// Package testutil defines internal support code for writing tests.
+package testutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/creachadair/jrpc2"
+	"github.com/creachadair/jrpc2/channel"
+)
+
+// ParseRequest parses a single JSON request object.
+func ParseRequest(s string) (req *jrpc2.Request, err error) {
+	cch, sch := channel.Direct()
+
+	srv := jrpc2.NewServer(requestStub{req: &req}, nil).Start(sch)
+	defer func() {
+		cch.Close()
+		serr := srv.Wait()
+		if err == nil {
+			err = serr
+		}
+	}()
+
+	if err := cch.Send([]byte(s)); err != nil {
+		srv.Stop()
+		return nil, err
+	} else if _, err := cch.Recv(); err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+// MustParseRequest calls ParseRequest and fails t if it reports an error.
+func MustParseRequest(t *testing.T, s string) *jrpc2.Request {
+	t.Helper()
+
+	req, err := ParseRequest(s)
+	if err != nil {
+		t.Fatalf("Parsing %#q failed: %v", s, err)
+	}
+	return req
+}
+
+type requestStub struct{ req **jrpc2.Request }
+
+func (r requestStub) Assign(context.Context, string) jrpc2.Handler { return r }
+
+func (r requestStub) Handle(_ context.Context, req *jrpc2.Request) (interface{}, error) {
+	*r.req = req
+	return nil, nil
+}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 Michael J. Fromberger. All Rights Reserved.
+
+package testutil_test
+
+import (
+	"testing"
+
+	"github.com/creachadair/jrpc2/internal/testutil"
+)
+
+func TestParseRequest(t *testing.T) {
+	t.Run("Invalid", func(t *testing.T) {
+		req, err := testutil.ParseRequest(`{this is invalid}`)
+		if err == nil {
+			t.Errorf("ParseRequest: got %+v, wanted error", req)
+		} else {
+			t.Logf("Invalid OK: %v", err)
+		}
+	})
+	t.Run("Call", func(t *testing.T) {
+		req := testutil.MustParseRequest(t, `{"jsonrpc":"2.0","id":1,"method":"OK"}`)
+		t.Logf("Call OK: %+v", req)
+	})
+	t.Run("Notification", func(t *testing.T) {
+		req := testutil.MustParseRequest(t, `{"jsonrpc":"2.0","id":null,"method":"OK"}`)
+		t.Logf("Note OK: %+v", req)
+	})
+}

--- a/jhttp/bridge.go
+++ b/jhttp/bridge.go
@@ -91,9 +91,6 @@ func (b Bridge) serveInternal(w http.ResponseWriter, req *http.Request) error {
 	// *jrpc2.Client detangles batch order so that responses come back in the
 	// same order (modulo notifications) even if the server response did not
 	// preserve order.
-	//
-	// Note that we don't check individual request structure; if the request is
-	// invalid the server will generate an error for it.
 
 	// Generate request specifications for the client.
 	var inboundID []string                // for requests

--- a/jhttp/jhttp_test.go
+++ b/jhttp/jhttp_test.go
@@ -131,7 +131,7 @@ func TestBridge_parseRequest(t *testing.T) {
 	const wantReply = `{"jsonrpc":"2.0","id":100,"result":0}`
 
 	b := jhttp.NewBridge(testService, &jhttp.BridgeOptions{
-		ParseRequest: func(req *http.Request) ([]*jrpc2.Request, error) {
+		ParseRequest: func(req *http.Request) ([]*jrpc2.ParsedRequest, error) {
 			action := req.Header.Get("x-test-header")
 			if action == "fail" {
 				return nil, errors.New("parse hook reporting failure")

--- a/jhttp/jhttp_test.go
+++ b/jhttp/jhttp_test.go
@@ -110,7 +110,7 @@ func TestBridge(t *testing.T) {
 		}
 	})
 
-	// Verify that invalid IDs are not swallowed (see #80).
+	// Verify that an invalid ID is not swallowed by the remapping process (see #80).
 	t.Run("PostInvalidID", func(t *testing.T) {
 		got := mustPost(t, hsrv.URL, `{
         "jsonrpc": "2.0",
@@ -118,7 +118,7 @@ func TestBridge(t *testing.T) {
         "method": "Test1"
       }`, http.StatusOK)
 
-		const exp = `{}`
+		const exp = `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"invalid request ID"}}`
 		if got != exp {
 			t.Errorf("POST body: got %#q, want %#q", got, exp)
 		}

--- a/jhttp/jhttp_test.go
+++ b/jhttp/jhttp_test.go
@@ -110,6 +110,20 @@ func TestBridge(t *testing.T) {
 		}
 	})
 
+	// Verify that invalid IDs are not swallowed (see #80).
+	t.Run("PostInvalidID", func(t *testing.T) {
+		got := mustPost(t, hsrv.URL, `{
+        "jsonrpc": "2.0",
+        "id": ["this is totally bogus"],
+        "method": "Test1"
+      }`, http.StatusOK)
+
+		const exp = `{}`
+		if got != exp {
+			t.Errorf("POST body: got %#q, want %#q", got, exp)
+		}
+	})
+
 	// Verify that a notification returns an empty success.
 	t.Run("PostNotification", func(t *testing.T) {
 		got := mustPost(t, hsrv.URL, `{

--- a/jrpc2_test.go
+++ b/jrpc2_test.go
@@ -601,9 +601,7 @@ func TestServer_nonLibraryClient(t *testing.T) {
 		}
 	}()
 
-	invalidIDMessage := func(s string) string {
-		return fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"error":{"code":-32600,"message":"invalid request ID"}}`, s)
-	}
+	const invalidIDMessage = `{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"invalid request ID"}}`
 	tests := []struct {
 		input, want string
 	}{
@@ -686,11 +684,11 @@ func TestServer_nonLibraryClient(t *testing.T) {
 			`{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"invalid request value"}}`},
 
 		// Various invalid ID checks.
-		{`{"jsonrpc":"2.0", "id":[], "method":"X"}`, invalidIDMessage("[]")},       // invalid ID: array
-		{`{"jsonrpc":"2.0", "id":["q"], "method":"X"}`, invalidIDMessage(`["q"]`)}, // "
-		{`{"jsonrpc":"2.0", "id":{}, "method":"X"}`, invalidIDMessage("{}")},       // invalid ID: object
-		{`{"jsonrpc":"2.0", "id":true, "method":"X"}`, invalidIDMessage("true")},   // invalid ID: Boolean
-		{`{"jsonrpc":"2.0", "id":false, "method":"X"}`, invalidIDMessage("false")}, // "
+		{`{"jsonrpc":"2.0", "id":[], "method":"X"}`, invalidIDMessage},    // invalid ID: array
+		{`{"jsonrpc":"2.0", "id":["q"], "method":"X"}`, invalidIDMessage}, // "
+		{`{"jsonrpc":"2.0", "id":{}, "method":"X"}`, invalidIDMessage},    // invalid ID: object
+		{`{"jsonrpc":"2.0", "id":true, "method":"X"}`, invalidIDMessage},  // invalid ID: Boolean
+		{`{"jsonrpc":"2.0", "id":false, "method":"X"}`, invalidIDMessage}, // "
 	}
 	for _, test := range tests {
 		if err := cli.Send([]byte(test.input)); err != nil {

--- a/json.go
+++ b/json.go
@@ -199,8 +199,9 @@ func (j *jmessage) parseJSON(data []byte) error {
 				j.fail(code.ParseError, "invalid version key")
 			}
 		case "id":
-			j.ID = val
-			if !isValidID(val) {
+			if isValidID(val) {
+				j.ID = val
+			} else {
 				j.fail(code.InvalidRequest, "invalid request ID")
 			}
 		case "method":


### PR DESCRIPTION
Add a new ParsedRequest type and return that instead of Request.
The latter is intended for consumption by Handler methods, and is hard to use
effectively in other contexts.  The new type exposes validation errors that
occur during parsing and allows the caller to detect specific problems with
each individual request in a batch separately.

This change also allows us to consolidate the checking of version errors, and
to remove most of the special case checks inside the client and server.

- Update the jhttp.Bridge to use the new ParsedRequest type.

- Update test cases. In cases where we really needed a jrpc2.Request, use the
  newly introduced internal/testutil package, which uses the server plumbing to
  render a request.

Fixes #80.