### PR TITLE
feat: expose function for building error responses

### DIFF
--- a/error.go
+++ b/error.go
@@ -73,3 +73,10 @@ var ErrConnClosed = errors.New("client connection is closed")
 func Errorf(code code.Code, msg string, args ...interface{}) *Error {
 	return &Error{Code: code, Message: fmt.Sprintf(msg, args...)}
 }
+
+// ErrorResponse returns a Response with the provided Error.
+func ErrorResponse(err *Error) Response {
+	return Response{
+		err: err,
+	}
+}

--- a/jrpc2_test.go
+++ b/jrpc2_test.go
@@ -1375,3 +1375,11 @@ func TestServer_newContext(t *testing.T) {
 		t.Errorf("Call failed: %v", err)
 	}
 }
+
+func TestErrorResponse(t *testing.T) {
+	err := jrpc2.Errorf(code.InvalidParams, "invalid params")
+	resp := jrpc2.ErrorResponse(err)
+	if resp.Error() != err {
+		t.Errorf(fmt.Sprintf("ErrorResponse: got %v, expected %v", resp.Error(), err))
+	}
+}


### PR DESCRIPTION
I'm building a proxy and have hit an edge case where I need to construct and return a `jrpc2.Response` with an error:

```go
reqs, err := jrpc2.ParseRequests(data)
if err != nil {
	// return a -32700 Parse Error
    ...
}
```

Since all the fields of `jrpc2.Response` are package private I've added a small utility function. 