### PR TITLE
code: remove the code registration hooks

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -36,8 +36,8 @@ type ErrCoder interface {
 // It also satisfies the ErrCoder interface, allowing the code to be recovered.
 type codeError Code
 
-// Error satisfies the error interface using the registered string for the
-// code, if one is defined, or else a placeholder that describes the value.
+// Error satisfies the error interface using the built-in string for the code,
+// if one is defined, or else a placeholder that describes the value.
 func (c codeError) Error() string { return Code(c).String() }
 
 // ErrCode trivially satisfies the ErrCoder interface.
@@ -51,7 +51,7 @@ func (c codeError) Is(err error) bool {
 
 // Err converts c to an error value, which is nil for code.NoError and
 // otherwise an error value whose code is c and whose text is based on the
-// registered string for c if one exists.
+// built-in string for c if one exists.
 func (c Code) Err() error {
 	if c == NoError {
 		return nil

--- a/code/code.go
+++ b/code/code.go
@@ -88,22 +88,6 @@ var stdError = map[Code]string{
 	DeadlineExceeded: "deadline exceeded",
 }
 
-// Register adds a new Code value with the specified message string.  This
-// function will panic if the proposed value is already registered with a
-// different string.
-//
-// Registering a code allows you to control the string returned by the String
-// method for the code value you specify.  It is not necessary to register a
-// code before using it. An unregistered code renders a generic string.
-func Register(value int32, message string) Code {
-	code := Code(value)
-	if s, ok := stdError[code]; ok && s != message {
-		panic(fmt.Sprintf("code %d is already registered for %q", code, s))
-	}
-	stdError[code] = message
-	return code
-}
-
 // FromError returns a Code to categorize the specified error.
 // If err == nil, it returns code.NoError.
 // If err is (or wraps) an ErrCoder, it returns the reported code value.

--- a/code/code_test.go
+++ b/code/code_test.go
@@ -12,27 +12,6 @@ import (
 	"github.com/creachadair/jrpc2/code"
 )
 
-func TestRegistration(t *testing.T) {
-	const message = "fun for the whole family"
-	c := code.Register(-100, message)
-	if got := c.String(); got != message {
-		t.Errorf("Register(-100): got %q, want %q", got, message)
-	} else if c != -100 {
-		t.Errorf("Register(-100): got %d instead", c)
-	}
-}
-
-func TestRegistrationError(t *testing.T) {
-	defer func() {
-		if v := recover(); v != nil {
-			t.Logf("Register correctly panicked: %v", v)
-		} else {
-			t.Fatalf("Register should have panicked on input %d, but did not", code.ParseError)
-		}
-	}()
-	code.Register(int32(code.ParseError), "bogus")
-}
-
 type testCoder code.Code
 
 func (t testCoder) ErrCode() code.Code { return code.Code(t) }
@@ -91,12 +70,10 @@ func TestErr(t *testing.T) {
 		code code.Code
 		want error
 	}
-	code.Register(1, "look for the bear necessities")
-	code.Register(2, "the simple bear necessities")
 	tests := []test{
 		{code.NoError, nil},
 		{0, errors.New("error code 0")},
-		{1, errors.New("look for the bear necessities")},
+		{1, errors.New("error code 1")},
 		{-17, errors.New("error code -17")},
 	}
 


### PR DESCRIPTION
In practice any package that wants to define custom codes has to keep track of them anyway, so that the client can coordinate with the server. The additional hook for cosmetics in the default error string is just not worthwhile.

Updates #46.