### PR TITLE
client: improve handling of stopped clients

### DIFF
--- a/opts.go
+++ b/opts.go
@@ -120,6 +120,11 @@ type ClientOptions struct {
 	// Note that the hook does not receive the request context, which has
 	// already ended by the time the hook is called.
 	OnCancel func(cli *Client, rsp *Response)
+
+	// If set, this function is called when the client is stopped, either by
+	// calling its Close method or by disconnection of its channel.  The
+	// arguments are the client itself and the error that caused it to stop.
+	OnStop func(cli *Client, err error)
 }
 
 func (c *ClientOptions) logFunc() func(string, ...any) {
@@ -142,6 +147,13 @@ func (c *ClientOptions) handleCancel() func(*Client, *Response) {
 		return nil
 	}
 	return c.OnCancel
+}
+
+func (c *ClientOptions) handleStop() func(*Client, error) {
+	if c == nil || c.OnStop == nil {
+		return func(*Client, error) {}
+	}
+	return c.OnStop
 }
 
 func (c *ClientOptions) handleCallback() func(context.Context, *jmessage) []byte {


### PR DESCRIPTION
A client can be stopped by calling its Close method, or by a failure of its
connection to the server. The user of the client does not have a way to handle
this gracefully.

Add an IsStopped method to the *jrpc2.Client, allowing the caller to check
whether the client is still alive explicitly.

Add an optional OnStop callback that will be invoked when the client closes,
allowing the caller to handle cleanup tasks automatically.

Updates #102
