### PR TITLE
jhttp: allow content-type to include a charset

### DIFF
--- a/jhttp/bridge.go
+++ b/jhttp/bridge.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 
 	"github.com/creachadair/jrpc2"
@@ -57,8 +58,12 @@ func (b Bridge) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		if req.Header.Get("Content-Type") != "application/json" {
-			w.WriteHeader(http.StatusUnsupportedMediaType)
+		mt, params, _ := mime.ParseMediaType(req.Header.Get("Content-Type"))
+		if mt != "application/json" {
+			http.Error(w, "content-type must be application/json", http.StatusUnsupportedMediaType)
+			return
+		} else if cs, ok := params["charset"]; ok && cs != "utf-8" && cs != "utf8" {
+			http.Error(w, "invalid content-type charset", http.StatusUnsupportedMediaType)
 			return
 		}
 	}

--- a/jhttp/jhttp_test.go
+++ b/jhttp/jhttp_test.go
@@ -92,11 +92,10 @@ func TestBridge(t *testing.T) {
 
 	// Verify that the charset, if provided, is utf-8.
 	t.Run("PostInvalidCharset", func(t *testing.T) {
-		rsp, err := http.Post(hsrv.URL, "application/json; charset=iso-8859-1", strings.NewReader(`{}`))
-		if err != nil {
-			t.Fatalf("POST request failed: %v", err)
-		} else if got, want := rsp.StatusCode, http.StatusUnsupportedMediaType; got != want {
-			t.Errorf("POST response code: got %v, want %v", got, want)
+		got := mustPost(t, hsrv.URL, "iso-8859-1", "{}", http.StatusUnsupportedMediaType)
+		const want = "invalid content-type charset\n"
+		if got != want {
+			t.Errorf("POST response body: got %q, want %q", got, want)
 		}
 	})
 


### PR DESCRIPTION
Accept "utf8" and "utf-8".

Fixes #110.
