### PR TITLE
jhttp: make the Bridge preserve batch status

### DIFF
--- a/internal_test.go
+++ b/internal_test.go
@@ -51,13 +51,13 @@ func TestParseRequests(t *testing.T) {
 		// A valid mixed batch.
 		{`[ {"jsonrpc": "2.0", "id": 1, "method": "A", "params": {}},
           {"jsonrpc": "2.0", "params": [5], "method": "B"} ]`, []*ParsedRequest{
-			{Method: "A", ID: "1", Params: json.RawMessage(`{}`)},
-			{Method: "B", Params: json.RawMessage(`[5]`)},
+			{Method: "A", ID: "1", Params: json.RawMessage(`{}`), Batch: true},
+			{Method: "B", Params: json.RawMessage(`[5]`), Batch: true},
 		}, nil},
 
 		// An invalid batch.
 		{`[{"id": 37, "method": "complain", "params":[]}]`, []*ParsedRequest{
-			{Method: "complain", ID: "37", Params: json.RawMessage(`[]`), Error: errInvalidVersion},
+			{Method: "complain", ID: "37", Params: json.RawMessage(`[]`), Batch: true, Error: errInvalidVersion},
 		}, nil},
 
 		// A broken request.

--- a/jhttp/jhttp_test.go
+++ b/jhttp/jhttp_test.go
@@ -69,6 +69,18 @@ func TestBridge(t *testing.T) {
 		}
 	})
 
+	// Verify that a single-request batch comes back as a batch too.
+	t.Run("PostBatchSingle", func(t *testing.T) {
+		got := mustPost(t, hsrv.URL, "", `[
+        {"jsonrpc":"2.0", "id": 11, "method": "Test1", "params": ["a", "solo", "request"]}
+      ]`, http.StatusOK)
+
+		const want = `[{"jsonrpc":"2.0","id":11,"result":3}]`
+		if got != want {
+			t.Errorf("POST body: got %#q, want %#q", got, want)
+		}
+	})
+
 	// Verify that a GET request reports an error.
 	t.Run("GetFail", func(t *testing.T) {
 		rsp, err := http.Get(hsrv.URL)

--- a/json.go
+++ b/json.go
@@ -23,6 +23,7 @@ func ParseRequests(msg []byte) ([]*ParsedRequest, error) {
 			ID:     string(fixID(req.ID)),
 			Method: req.M,
 			Params: req.P,
+			Batch:  req.batch,
 			Error:  req.err,
 		}
 	}
@@ -36,6 +37,7 @@ type ParsedRequest struct {
 	ID     string
 	Method string
 	Params json.RawMessage
+	Batch  bool // whether the request was part of a batch request
 	Error  *Error
 }
 


### PR DESCRIPTION
Although the JSON-RPC 2.0 spec does technically allow the responses from batch
requests to be returned separately, that is a peculiar corner and we shouldn't
rely on it.

Keep track of whether the original requests came in as a batch and use that
rather than response count to determine the encoding of the output from the
proxy.

Fixes #120
